### PR TITLE
Fix session loss on page refresh persisting info to localStorage

### DIFF
--- a/frontend/src/stores/auth.store.ts
+++ b/frontend/src/stores/auth.store.ts
@@ -4,6 +4,8 @@
  * Security considerations:
  * - Access tokens stored in memory only (XSS protection)
  * - Refresh tokens persisted to localStorage for session persistence
+ * - User info (non-sensitive: user_id, email, account_type) persisted to
+ *   localStorage to restore session state after page refresh
  * - Automatic token refresh on 401 responses handled by API interceptor
  */
 
@@ -12,12 +14,39 @@ import { ref, computed } from 'vue'
 import type { LoginResponse, AuthUser } from '@/types'
 
 const REFRESH_TOKEN_KEY = 'refresh_token'
+const USER_INFO_KEY = 'auth_user'
+
+/**
+ * Restore user info from localStorage.
+ * Returns null if no stored data or parsing fails.
+ */
+function restoreUserFromStorage(): AuthUser | null {
+  try {
+    const stored = localStorage.getItem(USER_INFO_KEY)
+    if (!stored) return null
+    return JSON.parse(stored) as AuthUser
+  } catch {
+    localStorage.removeItem(USER_INFO_KEY)
+    return null
+  }
+}
+
+/**
+ * Persist user info to localStorage.
+ */
+function persistUserToStorage(userData: AuthUser | null): void {
+  if (userData) {
+    localStorage.setItem(USER_INFO_KEY, JSON.stringify(userData))
+  } else {
+    localStorage.removeItem(USER_INFO_KEY)
+  }
+}
 
 export const useAuthStore = defineStore('auth', () => {
   // State - access token in memory only for security
   const accessToken = ref<string | null>(null)
   const refreshToken = ref<string | null>(localStorage.getItem(REFRESH_TOKEN_KEY))
-  const user = ref<AuthUser | null>(null)
+  const user = ref<AuthUser | null>(restoreUserFromStorage())
   const preferredLanguage = ref<string>(navigator.language.split('-')[0] || 'en')
   const isInitialized = ref<boolean>(false)
 
@@ -39,18 +68,21 @@ export const useAuthStore = defineStore('auth', () => {
   function setUser(loginResponse: LoginResponse): void {
     accessToken.value = loginResponse.access_token
     refreshToken.value = loginResponse.refresh_token
-    user.value = {
+    const userData: AuthUser = {
       user_id: loginResponse.user_id,
       email: loginResponse.email,
       is_email_verified: loginResponse.is_email_verified,
       account_type: loginResponse.account_type
     }
+    user.value = userData
     localStorage.setItem(REFRESH_TOKEN_KEY, loginResponse.refresh_token)
+    persistUserToStorage(userData)
   }
 
   function updateUser(updates: Partial<AuthUser>): void {
     if (user.value) {
       user.value = { ...user.value, ...updates }
+      persistUserToStorage(user.value)
     }
   }
 
@@ -59,6 +91,7 @@ export const useAuthStore = defineStore('auth', () => {
     refreshToken.value = null
     user.value = null
     localStorage.removeItem(REFRESH_TOKEN_KEY)
+    persistUserToStorage(null)
   }
 
   function setPreferredLanguage(lang: string): void {
@@ -68,6 +101,7 @@ export const useAuthStore = defineStore('auth', () => {
   function setEmailVerified(verified: boolean): void {
     if (user.value) {
       user.value.is_email_verified = verified
+      persistUserToStorage(user.value)
     }
   }
 

--- a/frontend/src/tests/stores/auth.store.spec.ts
+++ b/frontend/src/tests/stores/auth.store.spec.ts
@@ -186,6 +186,119 @@ describe('useAuthStore', () => {
     })
   })
 
+  describe('session persistence and restoration', () => {
+    it('should persist user info to localStorage on setUser', () => {
+      const store = useAuthStore()
+      const loginResponse: LoginResponse = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        user_id: 'user-123',
+        email: 'test@example.com',
+        is_email_verified: true,
+        account_type: 'verified'
+      }
+
+      store.setUser(loginResponse)
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'auth_user',
+        JSON.stringify({
+          user_id: 'user-123',
+          email: 'test@example.com',
+          is_email_verified: true,
+          account_type: 'verified'
+        })
+      )
+    })
+
+    it('should restore user info from localStorage on store initialization', () => {
+      // Simulate existing session data in localStorage (as if from previous session)
+      const storedUser = {
+        user_id: 'restored-user-123',
+        email: 'restored@example.com',
+        is_email_verified: true,
+        account_type: 'verified'
+      }
+
+      // Mock getItem to return stored values (simulating data from previous session)
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === 'auth_user') return JSON.stringify(storedUser)
+        if (key === 'refresh_token') return 'stored-refresh-token'
+        return null
+      })
+
+      // Create new Pinia and store (simulating page refresh)
+      setActivePinia(createPinia())
+      const store = useAuthStore()
+
+      // User info should be restored from localStorage
+      expect(store.userId).toBe('restored-user-123')
+      expect(store.userEmail).toBe('restored@example.com')
+      expect(store.isEmailVerified).toBe(true)
+      expect(store.accountType).toBe('verified')
+      expect(store.user).not.toBeNull()
+    })
+
+    it('should clear user info from localStorage on logout', () => {
+      const store = useAuthStore()
+      store.setUser({
+        access_token: 'token',
+        refresh_token: 'refresh',
+        token_type: 'bearer',
+        expires_in: 3600,
+        user_id: 'user-123',
+        email: 'test@example.com',
+        is_email_verified: true,
+        account_type: 'verified'
+      })
+
+      store.logout()
+
+      expect(localStorage.removeItem).toHaveBeenCalledWith('auth_user')
+    })
+
+    it('should persist updated user info when updateUser is called', () => {
+      const store = useAuthStore()
+      store.setUser({
+        access_token: 'token',
+        refresh_token: 'refresh',
+        token_type: 'bearer',
+        expires_in: 3600,
+        user_id: 'user-123',
+        email: 'test@example.com',
+        is_email_verified: false,
+        account_type: 'unverified'
+      })
+
+      vi.mocked(localStorage.setItem).mockClear()
+      store.updateUser({ is_email_verified: true })
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'auth_user',
+        expect.stringContaining('"is_email_verified":true')
+      )
+    })
+
+    it('should handle corrupted localStorage data gracefully', () => {
+      // Simulate corrupted data in localStorage
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === 'auth_user') return 'not-valid-json{'
+        return null
+      })
+
+      // Should not throw, should return null user
+      setActivePinia(createPinia())
+      const store = useAuthStore()
+
+      expect(store.user).toBeNull()
+      expect(store.isAuthenticated).toBe(false)
+      // Should also clean up corrupted data
+      expect(localStorage.removeItem).toHaveBeenCalledWith('auth_user')
+    })
+  })
+
   describe('computed properties', () => {
     it('isVerified should return true only for verified accounts', () => {
       const store = useAuthStore()


### PR DESCRIPTION
The auth store only persisted the refresh token but not user info, causing isAuthenticated to return false after refresh since user was null.

Added restoreUserFromStorage/persistUserToStorage helpers and tests for session restoration scenarios.