### PR TITLE
Standardize frontend layout consistency

### DIFF
--- a/frontend/src/assets/styles/components.css
+++ b/frontend/src/assets/styles/components.css
@@ -288,3 +288,42 @@
 .link-btn:hover {
   text-decoration: underline;
 }
+
+/* Name Suggestion Chips (used in context create/edit forms) */
+.name-chips-section {
+  margin-top: var(--spacing-1);
+}
+
+.name-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-top: 0.375rem;
+}
+
+.name-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: var(--spacing-1) 0.625rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-secondary);
+  background-color: var(--bg-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.name-chip:hover {
+  border-color: var(--color-primary-500);
+  background-color: var(--color-primary-50);
+  color: var(--color-primary-700);
+}
+
+.dark .name-chip {
+  color: var(--text-primary);
+}
+
+.dark .name-chip:hover {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: var(--color-primary-300);
+}

--- a/frontend/src/assets/styles/layout.css
+++ b/frontend/src/assets/styles/layout.css
@@ -68,17 +68,27 @@
   max-width: 1024px;
 }
 
+/* Page View - consistent vertical padding for all app pages */
+.page-view {
+  padding: var(--spacing-8) 0;
+}
+
 /* Page Header */
 .page-header {
   margin-bottom: var(--spacing-6);
 }
 
 .page-title {
-  margin-bottom: var(--spacing-2);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-1);
 }
 
 .page-description {
   color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  margin: 0;
 }
 
 /* Grid System */

--- a/frontend/src/components/common/BaseModal.vue
+++ b/frontend/src/components/common/BaseModal.vue
@@ -18,7 +18,7 @@ const handleClose = () => {
 
 <template>
   <TransitionRoot as="template" :show="isOpen">
-    <Dialog as="div" class="relative z-modal" @close="handleClose">
+    <Dialog as="div" class="modal-dialog" @close="handleClose">
       <TransitionChild
         as="template"
         enter="ease-out duration-300"
@@ -28,11 +28,11 @@ const handleClose = () => {
         leave-from="opacity-100"
         leave-to="opacity-0"
       >
-        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        <div class="modal-backdrop" />
       </TransitionChild>
 
-      <div class="fixed inset-0 z-10 overflow-y-auto">
-        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+      <div class="modal-scroll-container">
+        <div class="modal-layout">
           <TransitionChild
             as="template"
             enter="ease-out duration-300"
@@ -43,22 +43,22 @@ const handleClose = () => {
             leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
             <DialogPanel
-              class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full"
-              :class="maxWidth || 'sm:max-w-lg'"
+              class="modal-panel"
+              :class="maxWidth || 'modal-panel-default'"
             >
-              <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                <div class="sm:flex sm:items-start">
-                  <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left w-full">
-                    <DialogTitle v-if="title" as="h3" class="text-base font-semibold leading-6 text-gray-900 mb-4">
+              <div class="modal-header">
+                <div class="modal-header-layout">
+                  <div class="modal-content">
+                    <DialogTitle v-if="title" as="h3" class="modal-title">
                       {{ title }}
                     </DialogTitle>
-                    <div class="mt-2">
+                    <div class="modal-body">
                       <slot />
                     </div>
                   </div>
                 </div>
               </div>
-              <div v-if="$slots.footer" class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+              <div v-if="$slots.footer" class="modal-footer">
                 <slot name="footer" />
               </div>
             </DialogPanel>
@@ -70,194 +70,123 @@ const handleClose = () => {
 </template>
 
 <style scoped>
-
-.z-modal {
+.modal-dialog {
+  position: relative;
   z-index: var(--z-modal);
 }
 
-.fixed {
+.modal-backdrop {
   position: fixed;
-}
-
-.inset-0 {
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
-}
-
-.bg-gray-500 {
   background-color: var(--color-gray-500);
-}
-
-.bg-opacity-75 {
   opacity: 0.75;
-}
-
-.transition-opacity {
   transition-property: opacity;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
-.overflow-y-auto {
+.modal-scroll-container {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
   overflow-y: auto;
 }
 
-.flex {
+.modal-layout {
   display: flex;
-}
-
-.min-h-full {
   min-height: 100%;
-}
-
-.items-end {
   align-items: flex-end;
-}
-
-.justify-center {
   justify-content: center;
-}
-
-.p-4 {
   padding: var(--spacing-4);
-}
-
-.text-center {
   text-align: center;
 }
 
-.relative {
+.modal-panel {
   position: relative;
-}
-
-.transform {
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.overflow-hidden {
   overflow: hidden;
-}
-
-.rounded-lg {
   border-radius: var(--radius-lg);
-}
-
-.bg-white {
   background-color: var(--bg-secondary);
-}
-
-.text-left {
   text-align: left;
-}
-
-.shadow-xl {
   box-shadow: var(--shadow-xl);
-}
-
-.transition-all {
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
-.bg-gray-50 {
-  background-color: var(--bg-tertiary);
+.modal-header {
+  background-color: var(--bg-secondary);
+  padding: var(--spacing-5) var(--spacing-4) var(--spacing-4);
 }
 
-.px-4 {
-  padding-left: var(--spacing-4);
-  padding-right: var(--spacing-4);
+.modal-header-layout {
+  /* Stacked on mobile, flex on sm+ */
 }
 
-.py-3 {
-  padding-top: var(--spacing-3);
-  padding-bottom: var(--spacing-3);
-}
-
-.pb-4 {
-  padding-bottom: var(--spacing-4);
-}
-
-.pt-5 {
-  padding-top: var(--spacing-5);
-}
-
-.mt-3 {
+.modal-content {
   margin-top: var(--spacing-3);
-}
-
-.mt-2 {
-  margin-top: var(--spacing-2);
-}
-
-.mb-4 {
-  margin-bottom: var(--spacing-4);
-}
-
-.text-base {
-  font-size: var(--font-size-base);
-}
-
-.font-semibold {
-  font-weight: var(--font-weight-semibold);
-}
-
-.leading-6 {
-  line-height: 1.5rem;
-}
-
-.text-gray-900 {
-  color: var(--text-primary);
-}
-
-.w-full {
+  text-align: center;
   width: 100%;
 }
 
+.modal-title {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.5rem;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-4);
+}
+
+.modal-body {
+  margin-top: var(--spacing-2);
+}
+
+.modal-footer {
+  background-color: var(--bg-tertiary);
+  padding: var(--spacing-3) var(--spacing-4);
+}
+
+/* Responsive: sm (640px+) */
 @media (min-width: 640px) {
-  .sm\:items-center {
+  .modal-layout {
     align-items: center;
-  }
-  .sm\:p-0 {
     padding: 0;
   }
-  .sm\:my-8 {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-  }
-  .sm\:w-full {
+
+  .modal-panel {
+    margin-top: var(--spacing-8);
+    margin-bottom: var(--spacing-8);
     width: 100%;
   }
-  .sm\:max-w-lg {
+
+  .modal-panel-default {
     max-width: 32rem;
   }
-  .sm\:p-6 {
+
+  .modal-header {
     padding: var(--spacing-6);
-  }
-  .sm\:pb-4 {
     padding-bottom: var(--spacing-4);
   }
-  .sm\:flex {
+
+  .modal-header-layout {
     display: flex;
-  }
-  .sm\:items-start {
     align-items: flex-start;
   }
-  .sm\:ml-4 {
+
+  .modal-content {
     margin-left: var(--spacing-4);
-  }
-  .sm\:mt-0 {
     margin-top: 0;
-  }
-  .sm\:text-left {
     text-align: left;
   }
-  .sm\:flex-row-reverse {
+
+  .modal-footer {
+    display: flex;
     flex-direction: row-reverse;
-  }
-  .sm\:px-6 {
     padding-left: var(--spacing-6);
     padding-right: var(--spacing-6);
   }

--- a/frontend/src/components/profile/IdentityNameManager.vue
+++ b/frontend/src/components/profile/IdentityNameManager.vue
@@ -20,11 +20,13 @@ const showDeleteConfirm = ref(false)
 const deleteId = ref<string | null>(null)
 
 const nameTypes: { label: string; value: NameType }[] = [
+  { label: 'Full Name', value: 'full_name' },
   { label: 'Given Name', value: 'given' },
   { label: 'Family Name', value: 'family' },
   { label: 'Preferred Name', value: 'preferred' },
   { label: 'Legal Name', value: 'legal' },
-  { label: 'Nickname', value: 'custom' } // Mapping custom to nickname for UI simplicity if needed, or keep custom
+  { label: 'Patronymic', value: 'patronymic' },
+  { label: 'Nickname', value: 'custom' }
 ]
 
 const languageOptions = [
@@ -60,7 +62,7 @@ function startAdding() {
 function startEditing(name: IdentityName) {
   const lang = Object.keys(name.name_value)[0] || 'en'
   const val = Object.values(name.name_value)[0] || ''
-  
+
   form.value = {
     name_type: name.name_type,
     language: lang,
@@ -84,7 +86,7 @@ async function saveName() {
 
   try {
     const nameValue = { [form.value.language]: form.value.value }
-    
+
     if (editingId.value) {
       // Update
       const updated = await profileService.updateName(profileStore.profile.user_id, editingId.value, {
@@ -125,7 +127,7 @@ async function deleteName() {
   if (!profileStore.profile || !deleteId.value) return
 
   isDeleting.value = true
-  
+
   try {
     await profileService.deleteName(profileStore.profile.user_id, deleteId.value)
     // Refresh names from server to ensure sync, or filter local state
@@ -144,50 +146,50 @@ async function deleteName() {
 
 <template>
   <div class="identity-name-manager">
-    <div class="flex justify-between items-center mb-4">
-      <h3 class="text-lg font-medium text-gray-900">Identity Names</h3>
+    <div class="manager-header">
+      <h3 class="manager-title">Identity Names</h3>
       <BaseButton variant="secondary" size="sm" @click="startAdding" v-if="!isAdding">
         + Add Name
       </BaseButton>
     </div>
 
     <!-- Auto-primary hint -->
-    <div v-if="profileStore.autoPromotedPrimary" class="auto-primary-hint mb-3">
-      <p class="text-xs text-gray-600">
+    <div v-if="profileStore.autoPromotedPrimary" class="auto-primary-hint">
+      <p class="hint-text">
         No name was marked as primary, so the first name was selected automatically.
         Edit any name and check "Set as primary display name" to choose a different one.
       </p>
     </div>
 
     <!-- List -->
-    <div v-if="!isAdding" class="space-y-3">
-      <div v-if="profileStore.identityNames.length === 0" class="text-sm text-gray-500 italic">
+    <div v-if="!isAdding" class="names-list">
+      <div v-if="profileStore.identityNames.length === 0" class="empty-names">
         No additional names defined.
       </div>
-      
+
       <div
         v-for="name in profileStore.identityNames"
         :key="name.id"
-        class="flex items-center justify-between p-3 border border-gray-200 rounded-lg bg-white"
+        class="name-card"
       >
         <div>
-          <div class="flex items-center gap-2 mb-1">
-            <span class="font-medium text-gray-900">
+          <div class="name-info">
+            <span class="name-display">
               {{ Object.values(name.name_value)[0] }}
             </span>
             <BaseBadge variant="primary" size="sm">{{ name.name_type }}</BaseBadge>
             <BaseBadge v-if="name.is_primary" variant="success" size="sm">Primary</BaseBadge>
           </div>
-          <div class="text-xs text-gray-500 uppercase">
+          <div class="name-lang">
             {{ Object.keys(name.name_value)[0] }}
           </div>
         </div>
-        <div class="flex gap-2">
-          <button class="text-gray-400 hover:text-primary-600" @click="startEditing(name)">
+        <div class="name-actions">
+          <button class="action-edit" @click="startEditing(name)">
             <span class="sr-only">Edit</span>
             ✏️
           </button>
-          <button class="text-gray-400 hover:text-red-600" @click="confirmDelete(name.id)">
+          <button class="action-delete" @click="confirmDelete(name.id)">
             <span class="sr-only">Delete</span>
             🗑️
           </button>
@@ -196,12 +198,12 @@ async function deleteName() {
     </div>
 
     <!-- Add/Edit Form -->
-    <div v-else class="bg-gray-50 p-4 rounded-lg border border-gray-200">
-      <h4 class="text-sm font-medium text-gray-900 mb-3">
+    <div v-else class="name-form">
+      <h4 class="name-form-title">
         {{ editingId ? 'Edit Name' : 'Add New Name' }}
       </h4>
-      
-      <form @submit.prevent="saveName" class="space-y-3">
+
+      <form @submit.prevent="saveName" class="name-form-fields">
         <BaseSelect
           v-model="form.name_type"
           id="name_type"
@@ -209,9 +211,9 @@ async function deleteName() {
           :options="nameTypes"
           required
         />
-        
-        <div class="grid grid-cols-3 gap-3">
-          <div class="col-span-1">
+
+        <div class="form-grid">
+          <div class="form-col-narrow">
             <BaseSelect
               v-model="form.language"
               id="name_lang"
@@ -220,7 +222,7 @@ async function deleteName() {
               required
             />
           </div>
-          <div class="col-span-2">
+          <div class="form-col-wide">
             <BaseInput
               v-model="form.value"
               id="name_value"
@@ -232,15 +234,15 @@ async function deleteName() {
         </div>
 
         <div class="form-group">
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="checkbox" v-model="form.is_primary" class="rounded border-gray-300 text-primary-600" />
-            <span class="text-sm text-gray-700">Set as primary display name</span>
+          <label class="checkbox-group">
+            <input type="checkbox" v-model="form.is_primary" class="checkbox-input" />
+            <span class="checkbox-text">Set as primary display name</span>
           </label>
         </div>
 
-        <div v-if="error" class="text-sm text-red-600">{{ error }}</div>
+        <div v-if="error" class="form-error-text">{{ error }}</div>
 
-        <div class="flex justify-end gap-2 mt-4">
+        <div class="form-buttons">
           <BaseButton variant="ghost" size="sm" @click="isAdding = false">Cancel</BaseButton>
           <BaseButton type="submit" size="sm" :loading="isSaving">Save</BaseButton>
         </div>
@@ -253,9 +255,9 @@ async function deleteName() {
       title="Delete Name"
       @close="showDeleteConfirm = false"
     >
-      <p class="text-sm text-gray-500 mb-4">Are you sure you want to delete this name?</p>
+      <p class="modal-message">Are you sure you want to delete this name?</p>
       <template #footer>
-        <div class="flex justify-end gap-2 w-full">
+        <div class="modal-buttons">
           <BaseButton variant="ghost" @click="showDeleteConfirm = false">Cancel</BaseButton>
           <BaseButton variant="danger" :loading="isDeleting" @click="deleteName">Delete</BaseButton>
         </div>
@@ -265,69 +267,174 @@ async function deleteName() {
 </template>
 
 <style scoped>
+/* Header */
+.manager-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-4);
+}
+
+.manager-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+}
+
+/* Auto-primary hint */
 .auto-primary-hint {
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem;
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-primary);
+  background-color: var(--bg-secondary);
+  margin-bottom: var(--spacing-3);
+}
+
+.hint-text {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+/* Names list */
+.names-list > * + * {
+  margin-top: var(--spacing-3);
+}
+
+.empty-names {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* Name card */
+.name-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
   background-color: var(--bg-secondary);
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+.name-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-1);
 }
 
-/* Utility classes with dark mode support */
-.flex { display: flex; }
-.items-center { align-items: center; }
-.justify-between { justify-content: space-between; }
-.justify-end { justify-content: flex-end; }
-.gap-2 { gap: 0.5rem; }
-.gap-3 { gap: 0.75rem; }
-.mb-1 { margin-bottom: 0.25rem; }
-.mb-3 { margin-bottom: 0.75rem; }
-.mb-4 { margin-bottom: 1rem; }
-.mt-4 { margin-top: 1rem; }
-.p-3 { padding: 0.75rem; }
-.p-4 { padding: 1rem; }
-.space-y-3 > * + * { margin-top: 0.75rem; }
-.grid { display: grid; }
-.grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.col-span-1 { grid-column: span 1 / span 1; }
-.col-span-2 { grid-column: span 2 / span 2; }
-.w-full { width: 100%; }
-.border { border-width: 1px; }
-.rounded-lg { border-radius: 0.5rem; }
-.rounded { border-radius: 0.25rem; }
-.cursor-pointer { cursor: pointer; }
-.italic { font-style: italic; }
-.uppercase { text-transform: uppercase; }
+.name-display {
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+}
 
-/* Typography - dark mode aware */
-.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-.text-xs { font-size: 0.75rem; line-height: 1rem; }
-.font-medium { font-weight: 500; }
-.text-gray-900 { color: var(--text-primary); }
-.text-gray-700 { color: var(--text-secondary); }
-.text-gray-500 { color: var(--text-secondary); }
-.text-gray-400 { color: var(--text-tertiary); }
-.text-red-600 { color: var(--color-error-600); }
+.name-lang {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
 
-/* Backgrounds - dark mode aware */
-.bg-white { background-color: var(--bg-secondary); }
-.bg-gray-50 { background-color: var(--bg-secondary); }
-.border-gray-200 { border-color: var(--border-primary); }
-.border-gray-300 { border-color: var(--border-secondary); }
+/* Action buttons */
+.name-actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
 
-/* Interactive states */
-.hover\:text-primary-600:hover { color: var(--color-primary-600); }
-.hover\:text-red-600:hover { color: var(--color-error-600); }
+.action-edit,
+.action-delete {
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.action-edit:hover {
+  color: var(--color-primary-600);
+}
+
+.action-delete:hover {
+  color: var(--color-error-600);
+}
+
+/* Add/Edit form */
+.name-form {
+  background-color: var(--bg-tertiary);
+  padding: var(--spacing-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-primary);
+}
+
+.name-form-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-3);
+}
+
+.name-form-fields > * + * {
+  margin-top: var(--spacing-3);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-3);
+}
+
+.form-col-narrow {
+  grid-column: span 1 / span 1;
+}
+
+.form-col-wide {
+  grid-column: span 2 / span 2;
+}
+
+/* Checkbox */
+.checkbox-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
+
+.checkbox-input {
+  border-radius: var(--radius-sm);
+  border-color: var(--border-secondary);
+  color: var(--color-primary-600);
+}
+
+.checkbox-text {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+/* Form error */
+.form-error-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-error-600);
+}
+
+/* Form buttons */
+.form-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-4);
+}
+
+/* Modal content */
+.modal-message {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-4);
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+  width: 100%;
+}
 </style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -155,6 +155,7 @@
     "inheritFromProfile": "Leave empty to inherit from base profile",
     "overrides": "Profile Overrides",
     "overridesDescription": "These values will override your base profile when using this context. Leave empty to use your base profile values.",
+    "pickFromNames": "Pick from your identity names",
     "pseudonymousRestriction": "Note: Pseudonymous accounts cannot create legal or healthcare contexts.",
     "types": {
       "professional": "Professional",

--- a/frontend/src/views/AuditTrailView.vue
+++ b/frontend/src/views/AuditTrailView.vue
@@ -92,7 +92,7 @@ onMounted(loadEntries)
 
 <template>
   <div class="audit-trail-view">
-    <div class="container">
+    <div class="container container-lg">
       <div class="page-header">
         <div>
           <h1 class="page-title">{{ t('audit.title') }}</h1>
@@ -104,18 +104,20 @@ onMounted(loadEntries)
       <div class="filters-bar">
         <div class="filter-group">
           <BaseSelect
+            id="event_type_filter"
             :model-value="eventTypeFilter"
             :options="eventTypeOptions"
             :label="t('audit.filters.eventType')"
-            @update:model-value="(val: string) => { eventTypeFilter = val; applyFilters() }"
+            @update:model-value="(val: string | number) => { eventTypeFilter = String(val); applyFilters() }"
           />
         </div>
         <div class="filter-group">
           <BaseSelect
+            id="resource_type_filter"
             :model-value="resourceTypeFilter"
             :options="resourceTypeOptions"
             :label="t('audit.filters.resourceType')"
-            @update:model-value="(val: string) => { resourceTypeFilter = val; applyFilters() }"
+            @update:model-value="(val: string | number) => { resourceTypeFilter = String(val); applyFilters() }"
           />
         </div>
       </div>
@@ -180,23 +182,6 @@ onMounted(loadEntries)
 <style scoped>
 .audit-trail-view {
   padding: var(--spacing-8) 0;
-}
-
-.page-header {
-  margin-bottom: var(--spacing-6);
-}
-
-.page-title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--text-primary);
-  margin: 0 0 var(--spacing-1);
-}
-
-.page-description {
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
-  margin: 0;
 }
 
 .filters-bar {

--- a/frontend/src/views/ContextCreateView.vue
+++ b/frontend/src/views/ContextCreateView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, reactive } from 'vue'
+import { ref, computed, reactive, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore, useProfileStore, useUiStore } from '@/stores'
-import { contextService, getErrorMessage } from '@/services'
+import { contextService, profileService, getErrorMessage } from '@/services'
 import { CONTEXT_TYPES, CONTEXT_TYPE_META, type ContextType } from '@/types'
 import BaseInput from '@/components/common/BaseInput.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
@@ -35,6 +35,31 @@ const availableContextTypes = computed(() => {
     return CONTEXT_TYPES.filter((type) => type !== 'legal' && type !== 'healthcare')
   }
   return CONTEXT_TYPES
+})
+
+// Non-deprecated identity names for the "pick from names" chips
+const availableNames = computed(() =>
+  profileStore.identityNames.filter((n) => !n.is_deprecated)
+)
+
+function resolveNameValue(nameValue: Record<string, string>): string {
+  const lang = navigator.language.split('-')[0]
+  return nameValue[lang] ?? nameValue['en'] ?? Object.values(nameValue)[0] ?? ''
+}
+
+function pickName(resolved: string) {
+  form.display_name_override = resolved
+}
+
+onMounted(async () => {
+  if (authStore.userId && profileStore.identityNames.length === 0) {
+    try {
+      const names = await profileService.getNames(authStore.userId)
+      profileStore.setIdentityNames(names)
+    } catch {
+      // Non-critical: chips won't show, text input still works
+    }
+  }
 })
 
 async function handleSubmit() {
@@ -75,26 +100,26 @@ const handleCancel = () => {
 </script>
 
 <template>
-  <div class="context-create-view">
-    <div class="container container-md">
-      <div class="page-header mb-6">
-        <h1 class="text-2xl font-bold text-gray-900">{{ t('context.createNew') }}</h1>
-        <p class="text-gray-500 mt-1">{{ t('context.createDescription') }}</p>
+  <div class="page-view">
+    <div class="container container-lg">
+      <div class="page-header">
+        <h1 class="page-title">{{ t('context.createNew') }}</h1>
+        <p class="page-description">{{ t('context.createDescription') }}</p>
       </div>
 
-      <div v-if="error" class="alert alert-error mb-6">
+      <div v-if="error" class="alert alert-error create-error">
         {{ error }}
       </div>
 
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div class="create-grid">
         <!-- Main Form -->
-        <div class="lg:col-span-2">
+        <div class="form-column">
           <BaseCard>
             <form @submit.prevent="handleSubmit">
               <!-- Context Type Selection -->
-              <div class="mb-8">
-                <label class="block text-sm font-medium text-gray-700 mb-3">{{ t('context.type') }}</label>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div class="form-section">
+                <label class="section-label">{{ t('context.type') }}</label>
+                <div class="type-grid">
                   <div
                     v-for="contextType in availableContextTypes"
                     :key="contextType"
@@ -115,21 +140,21 @@ const handleCancel = () => {
                         </div>
                       </div>
                       <div v-if="form.context_type === contextType" class="card-check">
-                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <svg class="check-icon" viewBox="0 0 20 20" fill="currentColor">
                           <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                         </svg>
                       </div>
                     </div>
                   </div>
                 </div>
-                <p v-if="authStore.accountType === 'pseudonymous'" class="mt-2 text-sm text-warning-600">
+                <p v-if="authStore.accountType === 'pseudonymous'" class="pseudo-warning">
                   {{ t('context.pseudonymousRestriction') }}
                 </p>
               </div>
 
               <!-- Basic Info -->
-              <div class="mb-8">
-                <h3 class="text-lg font-medium text-gray-900 mb-4">Basic Information</h3>
+              <div class="form-section">
+                <h3 class="section-heading">Basic Information</h3>
                 <BaseInput
                   v-model="form.context_name"
                   id="context_name"
@@ -138,23 +163,23 @@ const handleCancel = () => {
                   required
                   :hint="t('context.nameHint')"
                 />
-                
-                <div class="form-group mb-4">
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" v-model="form.is_active" class="rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
-                    <span class="text-sm font-medium text-gray-700">{{ t('context.isActive') }}</span>
+
+                <div class="form-group">
+                  <label class="checkbox-group">
+                    <input type="checkbox" v-model="form.is_active" class="checkbox-input" />
+                    <span class="checkbox-text">{{ t('context.isActive') }}</span>
                   </label>
-                  <p class="text-xs text-gray-500 mt-1 ml-6">{{ t('context.isActiveHint') }}</p>
+                  <p class="checkbox-hint">{{ t('context.isActiveHint') }}</p>
                 </div>
               </div>
 
               <!-- Overrides -->
-              <div class="mb-8">
-                <div class="flex items-center justify-between mb-4">
-                  <h3 class="text-lg font-medium text-gray-900">{{ t('context.overrides') }}</h3>
-                  <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">Optional</span>
+              <div class="form-section">
+                <div class="overrides-header">
+                  <h3 class="section-heading">{{ t('context.overrides') }}</h3>
+                  <span class="optional-badge">Optional</span>
                 </div>
-                <p class="text-sm text-gray-500 mb-4">{{ t('context.overridesDescription') }}</p>
+                <p class="overrides-description">{{ t('context.overridesDescription') }}</p>
 
                 <BaseInput
                   v-model="form.display_name_override"
@@ -162,6 +187,22 @@ const handleCancel = () => {
                   :label="t('context.displayNameOverride')"
                   :placeholder="t('context.inheritFromProfile')"
                 />
+
+                <div v-if="availableNames.length > 0" class="name-chips-section">
+                  <span class="chips-label">{{ t('context.pickFromNames') }}</span>
+                  <div class="name-chips">
+                    <button
+                      v-for="name in availableNames"
+                      :key="name.id"
+                      type="button"
+                      class="name-chip"
+                      @click="pickName(resolveNameValue(name.name_value))"
+                    >
+                      <BaseBadge variant="primary" size="sm">{{ name.name_type }}</BaseBadge>
+                      <span class="chip-name-text">{{ resolveNameValue(name.name_value) }}</span>
+                    </button>
+                  </div>
+                </div>
 
                 <BaseInput
                   v-model="form.email_override"
@@ -179,19 +220,19 @@ const handleCancel = () => {
                   :placeholder="t('context.inheritFromProfile')"
                 />
 
-                <div class="form-group mb-4">
-                  <label for="bio" class="block text-sm font-medium text-gray-700 mb-1">{{ t('context.bio') }}</label>
+                <div class="form-group">
+                  <label for="bio" class="textarea-label">{{ t('context.bio') }}</label>
                   <textarea
                     id="bio"
                     v-model="form.bio"
                     rows="3"
-                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                    class="textarea-field"
                     :placeholder="t('context.bioPlaceholder')"
                   ></textarea>
                 </div>
               </div>
 
-              <div class="flex justify-end gap-4 pt-4 border-t border-gray-200">
+              <div class="form-footer">
                 <BaseButton variant="ghost" @click="handleCancel" :disabled="isSubmitting">
                   {{ t('common.cancel') }}
                 </BaseButton>
@@ -204,13 +245,13 @@ const handleCancel = () => {
         </div>
 
         <!-- Sidebar / Help -->
-        <div class="lg:col-span-1">
-          <BaseCard class="bg-blue-50 border-blue-100">
-            <h3 class="text-blue-900 font-medium mb-2">About Contexts</h3>
-            <p class="text-sm text-blue-800 mb-4">
+        <div class="help-column">
+          <BaseCard class="help-card">
+            <h3 class="help-title">About Contexts</h3>
+            <p class="help-text">
               Contexts allow you to present different sides of your identity to different applications.
             </p>
-            <ul class="text-sm text-blue-800 list-disc list-inside space-y-1">
+            <ul class="help-list">
               <li>Override your name and email</li>
               <li>Keep your phone number private</li>
               <li>Customize your bio per context</li>
@@ -223,8 +264,69 @@ const handleCancel = () => {
 </template>
 
 <style scoped>
-.context-create-view {
-  padding: var(--spacing-8) 0;
+/* Page header */
+.create-error {
+  margin-bottom: var(--spacing-6);
+}
+
+/* Layout grid */
+.create-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 1024px) {
+  .create-grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.form-column {
+  min-width: 0;
+}
+
+.help-column {
+  min-width: 0;
+}
+
+/* Form sections */
+.form-section {
+  margin-bottom: 2rem;
+}
+
+.section-label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-3);
+}
+
+.section-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-4);
+}
+
+/* Context type selection grid */
+.type-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-3);
+}
+
+@media (min-width: 640px) {
+  .type-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.pseudo-warning {
+  margin-top: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-warning-600);
 }
 
 /* Context Type Selection Cards */
@@ -282,6 +384,11 @@ const handleCancel = () => {
   color: var(--color-primary-600);
 }
 
+.check-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 /* Selected state overrides - high contrast */
 .context-type-card.is-selected .card-title {
   color: white;
@@ -295,96 +402,149 @@ const handleCancel = () => {
   color: white;
 }
 
-/* Tailwind-like utilities */
-.grid { display: grid; }
-.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.gap-6 { gap: 1.5rem; }
-.gap-3 { gap: 0.75rem; }
-.gap-4 { gap: 1rem; }
-.gap-2 { gap: 0.5rem; }
-.mb-8 { margin-bottom: 2rem; }
-.mb-6 { margin-bottom: 1.5rem; }
-.mb-4 { margin-bottom: 1rem; }
-.mb-3 { margin-bottom: 0.75rem; }
-.mb-2 { margin-bottom: 0.5rem; }
-.mb-1 { margin-bottom: 0.25rem; }
-.mt-1 { margin-top: 0.25rem; }
-.mt-2 { margin-top: 0.5rem; }
-.ml-1 { margin-left: 0.25rem; }
-.ml-6 { margin-left: 1.5rem; }
-.pt-4 { padding-top: 1rem; }
-.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.p-4 { padding: 1rem; }
-.w-full { width: 100%; }
-.h-5 { height: 1.25rem; }
-.w-5 { width: 1.25rem; }
-.flex { display: flex; }
-.items-center { align-items: center; }
-.justify-between { justify-content: space-between; }
-.justify-end { justify-content: flex-end; }
-.relative { position: relative; }
-.block { display: block; }
-.rounded-lg { border-radius: 0.5rem; }
-.rounded-md { border-radius: 0.375rem; }
-.rounded { border-radius: 0.25rem; }
-.border { border-width: 1px; }
-.border-t { border-top-width: 1px; }
-.border-gray-200 { border-color: var(--border-primary); }
-.border-gray-300 { border-color: var(--border-secondary); }
-.border-primary-500 { border-color: var(--color-primary-500); }
-.ring-2 { box-shadow: 0 0 0 2px var(--ring-color, var(--color-primary-500)); }
-.ring-primary-500 { --ring-color: var(--color-primary-500); }
-.border-blue-100 { border-color: var(--color-primary-200); }
-.bg-white { background-color: var(--bg-secondary); }
-.bg-gray-50 { background-color: var(--bg-secondary); }
-.bg-gray-100 { background-color: var(--bg-tertiary); }
-.bg-primary-50 { background-color: var(--color-primary-50); }
-.bg-blue-50 { background-color: var(--color-primary-50); }
-.text-gray-900 { color: var(--text-primary); }
-.text-gray-700 { color: var(--text-secondary); }
-.text-gray-500 { color: var(--text-secondary); }
-.text-primary-600 { color: var(--color-primary-600); }
-.text-warning-600 { color: var(--color-warning-600); }
-.text-blue-900 { color: var(--color-primary-700); }
-.text-blue-800 { color: var(--color-primary-600); }
-.hover\:bg-gray-50:hover { background-color: var(--bg-tertiary); }
+/* Checkbox */
+.checkbox-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
 
-/* Dark mode overrides for selection cards */
-:global(.dark) .bg-primary-50 {
-  background-color: rgba(59, 130, 246, 0.15);
+.checkbox-input {
+  border-radius: var(--radius-sm);
+  border-color: var(--border-secondary);
+  color: var(--color-primary-600);
 }
-:global(.dark) .bg-blue-50 {
+
+.checkbox-text {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+}
+
+.checkbox-hint {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  margin-top: var(--spacing-1);
+  margin-left: var(--spacing-6);
+}
+
+/* Overrides section */
+.overrides-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-4);
+}
+
+.overrides-header .section-heading {
+  margin-bottom: 0;
+}
+
+.optional-badge {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  background-color: var(--bg-tertiary);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--radius-sm);
+}
+
+.overrides-description {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-4);
+}
+
+/* Name chips */
+.chips-label {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+}
+
+.chip-name-text {
+  font-size: var(--font-size-sm);
+}
+
+/* Textarea */
+.textarea-label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-1);
+}
+
+.textarea-field {
+  display: block;
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-secondary);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.textarea-field:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* Form footer */
+.form-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-4);
+  padding-top: var(--spacing-4);
+  border-top: 1px solid var(--border-primary);
+}
+
+/* Help card */
+.help-card {
+  background-color: var(--color-primary-50);
+  border-color: var(--color-primary-200);
+}
+
+:global(.dark) .help-card {
   background-color: rgba(59, 130, 246, 0.1);
-}
-:global(.dark) .border-blue-100 {
   border-color: var(--color-primary-700);
 }
-:global(.dark) .text-blue-900 {
+
+.help-title {
+  color: var(--color-primary-700);
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--spacing-2);
+}
+
+:global(.dark) .help-title {
   color: var(--color-primary-300);
 }
-:global(.dark) .text-blue-800 {
+
+.help-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-600);
+  margin-bottom: var(--spacing-4);
+}
+
+:global(.dark) .help-text {
   color: var(--color-primary-400);
 }
-.font-bold { font-weight: 700; }
-.font-medium { font-weight: 500; }
-.text-2xl { font-size: 1.5rem; line-height: 2rem; }
-.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-.text-xs { font-size: 0.75rem; line-height: 1rem; }
-.cursor-pointer { cursor: pointer; }
-.shadow-sm { box-shadow: var(--shadow-sm); }
-.list-disc { list-style-type: disc; }
-.list-inside { list-style-position: inside; }
 
-@media (min-width: 640px) {
-  .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .sm\:text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+.help-list {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-600);
+  list-style-type: disc;
+  list-style-position: inside;
 }
 
-@media (min-width: 1024px) {
-  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .lg\:col-span-2 { grid-column: span 2 / span 2; }
-  .lg\:col-span-1 { grid-column: span 1 / span 1; }
+.help-list > li + li {
+  margin-top: var(--spacing-1);
+}
+
+:global(.dark) .help-list {
+  color: var(--color-primary-400);
 }
 </style>

--- a/frontend/src/views/ContextDetailView.vue
+++ b/frontend/src/views/ContextDetailView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore, useProfileStore, useUiStore } from '@/stores'
-import { contextService, getErrorMessage } from '@/services'
+import { contextService, profileService, getErrorMessage } from '@/services'
 import { CONTEXT_TYPE_META, type ContextProfileResponse, type ResolvedProfileResponse } from '@/types'
 import BaseCard from '@/components/common/BaseCard.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
@@ -37,8 +37,31 @@ const editForm = ref({
   is_active: true
 })
 
+// Non-deprecated identity names for the "pick from names" chips
+const availableNames = computed(() =>
+  profileStore.identityNames.filter((n) => !n.is_deprecated)
+)
+
+function resolveNameValue(nameValue: Record<string, string>): string {
+  const lang = navigator.language.split('-')[0]
+  return nameValue[lang] ?? nameValue['en'] ?? Object.values(nameValue)[0] ?? ''
+}
+
+function pickName(resolved: string) {
+  editForm.value.display_name_override = resolved
+}
+
 onMounted(async () => {
   await loadContext()
+  // Load identity names for the "pick from names" chips
+  if (authStore.userId && profileStore.identityNames.length === 0) {
+    try {
+      const names = await profileService.getNames(authStore.userId)
+      profileStore.setIdentityNames(names)
+    } catch {
+      // Non-critical: chips won't show, text input still works
+    }
+  }
 })
 
 async function loadContext() {
@@ -100,10 +123,10 @@ async function saveChanges() {
       is_active: editForm.value.is_active
     })
     context.value = updatedContext
-    
+
     // Reload resolved profile to reflect changes
     resolvedProfile.value = await contextService.getResolved(authStore.userId, contextId.value)
-    
+
     profileStore.updateContext(updatedContext)
     isEditing.value = false
     uiStore.addNotification({
@@ -141,32 +164,32 @@ async function deleteContext() {
 </script>
 
 <template>
-  <div class="context-detail-view">
-    <div class="container container-md">
-      <div class="page-header mb-6">
-        <router-link to="/contexts" class="back-link inline-flex items-center text-gray-500 hover:text-gray-900 mb-4">
-          <span class="mr-1">&larr;</span> {{ t('common.back') }}
+  <div class="page-view">
+    <div class="container container-lg">
+      <div class="page-header">
+        <router-link to="/contexts" class="back-link">
+          <span class="back-arrow">&larr;</span> {{ t('common.back') }}
         </router-link>
       </div>
 
-      <div v-if="isLoading" class="loading-state text-center py-12">
-        <div class="spinner spinner-lg mx-auto"></div>
-        <p class="mt-4 text-gray-500">{{ t('common.loading') }}</p>
+      <div v-if="isLoading" class="loading-container">
+        <div class="spinner spinner-lg loading-spinner"></div>
+        <p class="loading-text">{{ t('common.loading') }}</p>
       </div>
 
-      <div v-else-if="error && !context" class="alert alert-error mb-6">
+      <div v-else-if="error && !context" class="alert alert-error alert-spaced">
         {{ error }}
       </div>
 
       <template v-else-if="context">
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="detail-grid">
           <!-- Main Content -->
-          <div class="lg:col-span-2 space-y-6">
+          <div class="main-column">
             <!-- Context Header Card -->
             <BaseCard>
-              <div class="flex justify-between items-start">
+              <div class="context-header-row">
                 <div>
-                  <div class="flex items-center gap-3 mb-2">
+                  <div class="context-badges">
                     <BaseBadge :variant="context.context_type" size="md">
                       {{ CONTEXT_TYPE_META[context.context_type]?.label }}
                     </BaseBadge>
@@ -174,10 +197,10 @@ async function deleteContext() {
                       {{ t('context.inactive') }}
                     </BaseBadge>
                   </div>
-                  <h1 class="text-2xl font-bold text-gray-900">{{ context.context_name }}</h1>
-                  <p class="text-sm text-gray-500 mt-1">Created {{ new Date(context.created_at).toLocaleDateString() }}</p>
+                  <h1 class="context-title">{{ context.context_name }}</h1>
+                  <p class="context-meta">Created {{ new Date(context.created_at).toLocaleDateString() }}</p>
                 </div>
-                <div v-if="!isEditing" class="flex gap-2">
+                <div v-if="!isEditing" class="action-buttons">
                   <BaseButton variant="secondary" size="sm" @click="startEditing">
                     {{ t('common.edit') }}
                   </BaseButton>
@@ -191,45 +214,45 @@ async function deleteContext() {
             <!-- Resolved Profile Preview -->
             <BaseCard v-if="!isEditing && resolvedProfile">
               <template #header>
-                <h2 class="text-lg font-semibold">Resolved Profile</h2>
-                <p class="text-sm text-gray-500 font-normal mt-1">What applications see when using this context</p>
+                <h2 class="card-heading">Resolved Profile</h2>
+                <p class="resolved-subtitle">What applications see when using this context</p>
               </template>
-              
-              <div class="space-y-4">
+
+              <div class="fields-list">
                 <div class="field-group">
-                  <div class="flex justify-between items-center mb-1">
-                    <label class="text-xs font-medium text-gray-500 uppercase">Display Name</label>
+                  <div class="field-header">
+                    <label class="field-label-sm">Display Name</label>
                     <BaseBadge v-if="context.display_name_override" variant="info" size="sm">Custom</BaseBadge>
                     <BaseBadge v-else-if="resolvedProfile.display_name" variant="neutral" size="sm">Inherited</BaseBadge>
                   </div>
-                  <div class="text-gray-900">{{ resolvedProfile.display_name || 'Not set' }}</div>
+                  <div class="field-value-text">{{ resolvedProfile.display_name || 'Not set' }}</div>
                 </div>
 
                 <div class="field-group">
-                  <div class="flex justify-between items-center mb-1">
-                    <label class="text-xs font-medium text-gray-500 uppercase">Email</label>
+                  <div class="field-header">
+                    <label class="field-label-sm">Email</label>
                     <BaseBadge v-if="context.email_override" variant="info" size="sm">Custom</BaseBadge>
                     <BaseBadge v-else-if="resolvedProfile.email" variant="neutral" size="sm">Inherited</BaseBadge>
                   </div>
-                  <div class="text-gray-900">{{ resolvedProfile.email || 'Not set' }}</div>
+                  <div class="field-value-text">{{ resolvedProfile.email || 'Not set' }}</div>
                 </div>
 
                 <div class="field-group">
-                  <div class="flex justify-between items-center mb-1">
-                    <label class="text-xs font-medium text-gray-500 uppercase">Phone</label>
+                  <div class="field-header">
+                    <label class="field-label-sm">Phone</label>
                     <BaseBadge v-if="context.phone_override" variant="info" size="sm">Custom</BaseBadge>
                     <BaseBadge v-else-if="resolvedProfile.phone" variant="neutral" size="sm">Inherited</BaseBadge>
                   </div>
-                  <div class="text-gray-900">{{ resolvedProfile.phone || 'Not set' }}</div>
+                  <div class="field-value-text">{{ resolvedProfile.phone || 'Not set' }}</div>
                 </div>
 
                 <div class="field-group">
-                  <div class="flex justify-between items-center mb-1">
-                    <label class="text-xs font-medium text-gray-500 uppercase">Bio</label>
+                  <div class="field-header">
+                    <label class="field-label-sm">Bio</label>
                     <BaseBadge v-if="context.bio" variant="info" size="sm">Custom</BaseBadge>
                     <BaseBadge v-else-if="resolvedProfile.bio" variant="neutral" size="sm">Inherited</BaseBadge>
                   </div>
-                  <div class="text-gray-900 whitespace-pre-wrap">{{ resolvedProfile.bio || 'Not set' }}</div>
+                  <div class="field-value-bio">{{ resolvedProfile.bio || 'Not set' }}</div>
                 </div>
               </div>
             </BaseCard>
@@ -237,10 +260,10 @@ async function deleteContext() {
             <!-- Edit Form -->
             <BaseCard v-if="isEditing">
               <template #header>
-                <h2 class="text-lg font-semibold">Edit Context</h2>
+                <h2 class="card-heading">Edit Context</h2>
               </template>
 
-              <form @submit.prevent="saveChanges" class="space-y-4">
+              <form @submit.prevent="saveChanges" class="edit-form">
                 <BaseInput
                   v-model="editForm.context_name"
                   id="context_name"
@@ -248,15 +271,31 @@ async function deleteContext() {
                   required
                 />
 
-                <div class="border-t border-gray-200 my-4 pt-4">
-                  <h3 class="text-sm font-medium text-gray-900 mb-4">Overrides</h3>
-                  
+                <div class="edit-divider">
+                  <h3 class="overrides-heading">Overrides</h3>
+
                   <BaseInput
                     v-model="editForm.display_name_override"
                     id="display_name"
                     :label="t('context.displayNameOverride')"
                     :placeholder="t('context.inheritFromProfile')"
                   />
+
+                  <div v-if="availableNames.length > 0" class="name-chips-section chips-spaced">
+                    <span class="chips-label">{{ t('context.pickFromNames') }}</span>
+                    <div class="name-chips">
+                      <button
+                        v-for="name in availableNames"
+                        :key="name.id"
+                        type="button"
+                        class="name-chip"
+                        @click="pickName(resolveNameValue(name.name_value))"
+                      >
+                        <BaseBadge variant="primary" size="sm">{{ name.name_type }}</BaseBadge>
+                        <span class="chip-name-text">{{ resolveNameValue(name.name_value) }}</span>
+                      </button>
+                    </div>
+                  </div>
 
                   <BaseInput
                     v-model="editForm.email_override"
@@ -274,26 +313,26 @@ async function deleteContext() {
                     :placeholder="t('context.inheritFromProfile')"
                   />
 
-                  <div class="form-group mb-4">
-                    <label for="bio" class="block text-sm font-medium text-gray-700 mb-1">{{ t('context.bio') }}</label>
+                  <div class="form-group textarea-group">
+                    <label for="bio" class="textarea-label">{{ t('context.bio') }}</label>
                     <textarea
                       id="bio"
                       v-model="editForm.bio"
                       rows="3"
-                      class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                      class="textarea-field"
                       :placeholder="t('context.inheritFromProfile')"
                     ></textarea>
                   </div>
                 </div>
 
                 <div class="form-group">
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" v-model="editForm.is_active" class="rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
-                    <span class="text-sm font-medium text-gray-700">{{ t('context.isActive') }}</span>
+                  <label class="checkbox-group">
+                    <input type="checkbox" v-model="editForm.is_active" class="checkbox-input" />
+                    <span class="checkbox-text">{{ t('context.isActive') }}</span>
                   </label>
                 </div>
 
-                <div class="flex justify-end gap-3 pt-4">
+                <div class="form-actions">
                   <BaseButton variant="ghost" @click="cancelEditing" :disabled="isSaving">
                     {{ t('common.cancel') }}
                   </BaseButton>
@@ -306,32 +345,32 @@ async function deleteContext() {
           </div>
 
           <!-- Sidebar -->
-          <div class="lg:col-span-1 space-y-6">
+          <div class="sidebar-column">
             <!-- Connected Apps (Placeholder) -->
             <BaseCard>
               <template #header>
-                <h2 class="text-lg font-semibold">Connected Apps</h2>
+                <h2 class="card-heading">Connected Apps</h2>
               </template>
-              <div class="text-sm text-gray-500 text-center py-4">
+              <div class="connected-empty">
                 No applications connected to this context.
               </div>
             </BaseCard>
 
             <!-- Inheritance Legend -->
-            <BaseCard class="bg-gray-50">
-              <h3 class="text-sm font-medium text-gray-900 mb-3">Field Inheritance</h3>
-              <div class="space-y-3">
-                <div class="flex items-center gap-2">
+            <BaseCard class="legend-card">
+              <h3 class="legend-title">Field Inheritance</h3>
+              <div class="legend-items">
+                <div class="legend-row">
                   <BaseBadge variant="neutral" size="sm">Inherited</BaseBadge>
-                  <span class="text-xs text-gray-600">Value comes from your base profile</span>
+                  <span class="legend-desc">Value comes from your base profile</span>
                 </div>
-                <div class="flex items-center gap-2">
+                <div class="legend-row">
                   <BaseBadge variant="info" size="sm">Custom</BaseBadge>
-                  <span class="text-xs text-gray-600">Value is specific to this context</span>
+                  <span class="legend-desc">Value is specific to this context</span>
                 </div>
-                <div class="flex items-center gap-2">
-                  <span class="text-xs text-gray-500 italic">No badge</span>
-                  <span class="text-xs text-gray-600">Not set in base profile or this context</span>
+                <div class="legend-row">
+                  <span class="legend-no-badge">No badge</span>
+                  <span class="legend-desc">Not set in base profile or this context</span>
                 </div>
               </div>
             </BaseCard>
@@ -345,17 +384,17 @@ async function deleteContext() {
         :title="t('context.deleteConfirmTitle')"
         @close="showDeleteConfirm = false"
       >
-        <p class="text-sm text-gray-500 mb-4">
+        <p class="modal-message">
           {{ t('context.deleteConfirmMessage') }}
         </p>
-        <div class="bg-red-50 border border-red-100 rounded-md p-3 mb-4">
-          <p class="text-xs text-red-800">
+        <div class="delete-warning">
+          <p class="delete-warning-text">
             <strong>Warning:</strong> Any applications using this context will lose access to your identity information.
           </p>
         </div>
-        
+
         <template #footer>
-          <div class="flex justify-end gap-3 w-full">
+          <div class="modal-actions">
             <BaseButton variant="ghost" @click="showDeleteConfirm = false">
               {{ t('common.cancel') }}
             </BaseButton>
@@ -370,69 +409,303 @@ async function deleteContext() {
 </template>
 
 <style scoped>
-.context-detail-view {
-  padding: var(--spacing-8) 0;
+/* Back link */
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-4);
+  text-decoration: none;
 }
 
-/* Tailwind-like utilities */
-.grid { display: grid; }
-.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.gap-6 { gap: 1.5rem; }
-.gap-3 { gap: 0.75rem; }
-.gap-2 { gap: 0.5rem; }
-.space-y-6 > * + * { margin-top: 1.5rem; }
-.space-y-4 > * + * { margin-top: 1rem; }
-.space-y-3 > * + * { margin-top: 0.75rem; }
-.mb-6 { margin-bottom: 1.5rem; }
-.mb-4 { margin-bottom: 1rem; }
-.mb-3 { margin-bottom: 0.75rem; }
-.mb-2 { margin-bottom: 0.5rem; }
-.mb-1 { margin-bottom: 0.25rem; }
-.mt-1 { margin-top: 0.25rem; }
-.mt-4 { margin-top: 1rem; }
-.mr-1 { margin-right: 0.25rem; }
-.my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.pt-4 { padding-top: 1rem; }
-.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.p-3 { padding: 0.75rem; }
-.text-center { text-align: center; }
-.text-2xl { font-size: 1.5rem; line-height: 2rem; }
-.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-.text-xs { font-size: 0.75rem; line-height: 1rem; }
-.font-bold { font-weight: 700; }
-.font-semibold { font-weight: 600; }
-.font-medium { font-weight: 500; }
-.font-normal { font-weight: 400; }
-.uppercase { text-transform: uppercase; }
-.text-gray-900 { color: var(--text-primary); }
-.text-gray-600 { color: var(--text-secondary); }
-.text-gray-500 { color: var(--text-secondary); }
-.text-red-800 { color: #991b1b; }
-.bg-gray-50 { background-color: var(--bg-secondary); }
-.bg-red-50 { background-color: #fef2f2; }
-.border-t { border-top-width: 1px; }
-.border-gray-200 { border-color: var(--border-primary); }
-.border-gray-300 { border-color: var(--border-secondary); }
-.border-red-100 { border-color: #fee2e2; }
-.rounded-md { border-radius: 0.375rem; }
-.rounded { border-radius: 0.25rem; }
-.shadow-sm { box-shadow: var(--shadow-sm); }
-.flex { display: flex; }
-.items-center { align-items: center; }
-.items-start { align-items: flex-start; }
-.justify-between { justify-content: space-between; }
-.justify-end { justify-content: flex-end; }
-.inline-flex { display: inline-flex; }
-.block { display: block; }
-.w-full { width: 100%; }
-.whitespace-pre-wrap { white-space: pre-wrap; }
-.cursor-pointer { cursor: pointer; }
+.back-link:hover {
+  color: var(--text-primary);
+}
+
+.back-arrow {
+  margin-right: var(--spacing-1);
+}
+
+/* Loading state */
+.loading-container {
+  text-align: center;
+  padding: var(--spacing-12) 0;
+}
+
+.loading-spinner {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.loading-text {
+  margin-top: var(--spacing-4);
+  color: var(--text-secondary);
+}
+
+.alert-spaced {
+  margin-bottom: var(--spacing-6);
+}
+
+/* Detail grid layout */
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
 
 @media (min-width: 1024px) {
-  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .lg\:col-span-2 { grid-column: span 2 / span 2; }
-  .lg\:col-span-1 { grid-column: span 1 / span 1; }
+  .detail-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.main-column {
+  grid-column: 1;
+}
+
+@media (min-width: 1024px) {
+  .main-column {
+    grid-column: span 2 / span 2;
+  }
+}
+
+.main-column > * + * {
+  margin-top: var(--spacing-6);
+}
+
+.sidebar-column > * + * {
+  margin-top: var(--spacing-6);
+}
+
+/* Context header */
+.context-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.context-badges {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
+}
+
+.context-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+}
+
+.context-meta {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin-top: var(--spacing-1);
+}
+
+.action-buttons {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+/* Card elements */
+.card-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.resolved-subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-normal);
+  margin-top: var(--spacing-1);
+}
+
+/* Field display */
+.fields-list > * + * {
+  margin-top: var(--spacing-4);
+}
+
+.field-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-1);
+}
+
+.field-label-sm {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.field-value-text {
+  color: var(--text-primary);
+}
+
+.field-value-bio {
+  color: var(--text-primary);
+  white-space: pre-wrap;
+}
+
+/* Edit form */
+.edit-form > * + * {
+  margin-top: var(--spacing-4);
+}
+
+.edit-divider {
+  border-top: 1px solid var(--border-primary);
+  margin-top: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+  padding-top: var(--spacing-4);
+}
+
+.overrides-heading {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-4);
+}
+
+/* Name chips (uses global .name-chips-section, .name-chips, .name-chip from components.css) */
+.chips-spaced {
+  margin-bottom: var(--spacing-4);
+}
+
+.chips-label {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.chip-name-text {
+  font-size: var(--font-size-sm);
+}
+
+/* Textarea */
+.textarea-group {
+  margin-bottom: var(--spacing-4);
+}
+
+.textarea-label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-1);
+}
+
+.textarea-field {
+  display: block;
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-secondary);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  background-color: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.textarea-field:focus {
+  border-color: var(--color-primary-500);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary-100);
+}
+
+/* Checkbox */
+.checkbox-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
+
+.checkbox-input {
+  border-radius: var(--radius-sm);
+  border-color: var(--border-secondary);
+  color: var(--color-primary-600);
+}
+
+.checkbox-text {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+}
+
+/* Form actions */
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  padding-top: var(--spacing-4);
+}
+
+/* Sidebar - connected apps */
+.connected-empty {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  text-align: center;
+  padding: var(--spacing-4) 0;
+}
+
+/* Sidebar - inheritance legend */
+.legend-card {
+  background-color: var(--bg-tertiary);
+}
+
+.legend-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-3);
+}
+
+.legend-items > * + * {
+  margin-top: var(--spacing-3);
+}
+
+.legend-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.legend-desc {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.legend-no-badge {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* Modal content */
+.modal-message {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-4);
+}
+
+.delete-warning {
+  background-color: var(--color-error-50);
+  border: 1px solid #fee2e2;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+
+.delete-warning-text {
+  font-size: var(--font-size-xs);
+  color: #991b1b;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  width: 100%;
 }
 </style>

--- a/frontend/src/views/ContextsView.vue
+++ b/frontend/src/views/ContextsView.vue
@@ -40,34 +40,34 @@ const navigateToDetail = (id: string) => {
 </script>
 
 <template>
-  <div class="contexts-view">
+  <div class="page-view">
     <div class="container container-lg">
-      <div class="page-header flex justify-between items-center mb-8">
+      <div class="contexts-header">
         <div>
-          <h1 class="text-2xl font-bold text-gray-900">{{ t('context.title') }}</h1>
-          <p class="text-gray-500 mt-1">{{ t('context.description') }}</p>
+          <h1 class="page-title">{{ t('context.title') }}</h1>
+          <p class="page-description">{{ t('context.description') }}</p>
         </div>
         <BaseButton variant="primary" @click="navigateToCreate">
           {{ t('context.create') }}
         </BaseButton>
       </div>
 
-      <div v-if="isLoading" class="loading-state text-center py-12">
-        <div class="spinner spinner-lg mx-auto"></div>
-        <p class="mt-4 text-gray-500">{{ t('common.loading') }}</p>
+      <div v-if="isLoading" class="loading-container">
+        <div class="spinner spinner-lg loading-spinner"></div>
+        <p class="loading-text">{{ t('common.loading') }}</p>
       </div>
 
-      <div v-else-if="error" class="alert alert-error mb-6">
+      <div v-else-if="error" class="alert alert-error alert-spaced">
         {{ error }}
       </div>
 
       <div v-else-if="profileStore.contexts.length === 0" class="empty-state">
-        <BaseCard class="text-center py-12">
-          <div class="mx-auto w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4 text-2xl">
+        <BaseCard class="empty-card">
+          <div class="empty-icon">
             📇
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">No contexts yet</h3>
-          <p class="text-gray-500 mb-6 max-w-md mx-auto">
+          <h3 class="empty-title">No contexts yet</h3>
+          <p class="empty-description">
             Create your first identity context to share different information with different applications.
           </p>
           <BaseButton variant="primary" @click="navigateToCreate">
@@ -76,7 +76,7 @@ const navigateToDetail = (id: string) => {
         </BaseCard>
       </div>
 
-      <div v-else class="contexts-grid grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div v-else class="contexts-grid">
         <div
           v-for="context in profileStore.contexts"
           :key="context.id"
@@ -88,31 +88,31 @@ const navigateToDetail = (id: string) => {
           @keydown.enter="navigateToDetail(context.id)"
           @keydown.space.prevent="navigateToDetail(context.id)"
         >
-          <BaseCard class="h-full hover:shadow-md transition-shadow cursor-pointer border-l-4" :style="{ borderLeftColor: `var(--color-${CONTEXT_TYPE_META[context.context_type].color}-500)` }">
-            <div class="flex justify-between items-start mb-4">
+          <BaseCard class="context-card-item" :style="{ borderLeftColor: `var(--color-${CONTEXT_TYPE_META[context.context_type].color}-500)` }">
+            <div class="card-badges">
               <BaseBadge :variant="context.context_type">
                 {{ CONTEXT_TYPE_META[context.context_type]?.label }}
               </BaseBadge>
               <BaseBadge v-if="!context.is_active" variant="warning">
                 {{ t('context.inactive') }}
               </BaseBadge>
-              <BaseBadge v-else variant="success" size="sm" class="opacity-0 group-hover:opacity-100 transition-opacity">
+              <BaseBadge v-else variant="success" size="sm">
                 Active
               </BaseBadge>
             </div>
 
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">{{ context.context_name }}</h3>
-            
-            <div class="space-y-2 text-sm text-gray-600">
-              <div v-if="context.display_name_override" class="flex items-center gap-2">
-                <span class="text-xs font-medium text-gray-400 uppercase w-12">Name</span>
-                <span class="truncate">{{ context.display_name_override }}</span>
+            <h3 class="card-title">{{ context.context_name }}</h3>
+
+            <div class="override-list">
+              <div v-if="context.display_name_override" class="override-row">
+                <span class="override-label">Name</span>
+                <span class="override-value">{{ context.display_name_override }}</span>
               </div>
-              <div v-if="context.email_override" class="flex items-center gap-2">
-                <span class="text-xs font-medium text-gray-400 uppercase w-12">Email</span>
-                <span class="truncate">{{ context.email_override }}</span>
+              <div v-if="context.email_override" class="override-row">
+                <span class="override-label">Email</span>
+                <span class="override-value">{{ context.email_override }}</span>
               </div>
-              <div v-if="!context.display_name_override && !context.email_override" class="text-gray-400 italic">
+              <div v-if="!context.display_name_override && !context.email_override" class="override-fallback">
                 Inherits all fields
               </div>
             </div>
@@ -124,66 +124,153 @@ const navigateToDetail = (id: string) => {
 </template>
 
 <style scoped>
-.contexts-view {
-  padding: var(--spacing-8) 0;
+/* Page header */
+.contexts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-8);
 }
 
-/* Utility classes */
-.flex { display: flex; }
-.justify-between { justify-content: space-between; }
-.items-center { align-items: center; }
-.items-start { align-items: flex-start; }
-.mb-8 { margin-bottom: 2rem; }
-.mb-6 { margin-bottom: 1.5rem; }
-.mb-4 { margin-bottom: 1rem; }
-.mb-2 { margin-bottom: 0.5rem; }
-.mt-1 { margin-top: 0.25rem; }
-.mt-4 { margin-top: 1rem; }
-.mx-auto { margin-left: auto; margin-right: auto; }
-.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.text-center { text-align: center; }
-.text-2xl { font-size: 1.5rem; line-height: 2rem; }
-.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-.text-xs { font-size: 0.75rem; line-height: 1rem; }
-.font-bold { font-weight: 700; }
-.font-semibold { font-weight: 600; }
-.font-medium { font-weight: 500; }
-.text-gray-900 { color: var(--text-primary); }
-.text-gray-600 { color: var(--text-secondary); }
-.text-gray-500 { color: var(--text-secondary); }
-.text-gray-400 { color: var(--text-tertiary); }
-.bg-gray-100 { background-color: var(--bg-tertiary); }
-.rounded-full { border-radius: 9999px; }
-.w-16 { width: 4rem; }
-.h-16 { height: 4rem; }
-.h-full { height: 100%; }
-.w-12 { width: 3rem; }
-.max-w-md { max-width: 28rem; }
-.grid { display: grid; }
-.gap-6 { gap: 1.5rem; }
-.gap-2 { gap: 0.5rem; }
-.space-y-2 > * + * { margin-top: 0.5rem; }
-.truncate { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.italic { font-style: italic; }
-.border-l-4 { border-left-width: 4px; }
-.hover\:shadow-md:hover { box-shadow: var(--shadow-md); }
-.transition-shadow { transition: box-shadow 0.3s ease; }
-.cursor-pointer { cursor: pointer; }
+/* Loading state */
+.loading-container {
+  text-align: center;
+  padding: var(--spacing-12) 0;
+}
 
-/* Keyboard accessibility */
+.loading-spinner {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.loading-text {
+  margin-top: var(--spacing-4);
+  color: var(--text-secondary);
+}
+
+/* Alert spacing */
+.alert-spaced {
+  margin-bottom: var(--spacing-6);
+}
+
+/* Empty state */
+.empty-card {
+  text-align: center;
+  padding: var(--spacing-12) 0;
+}
+
+.empty-icon {
+  margin: 0 auto var(--spacing-4);
+  width: 4rem;
+  height: 4rem;
+  background-color: var(--bg-tertiary);
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-2xl);
+}
+
+.empty-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-2);
+}
+
+.empty-description {
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-6);
+  max-width: 28rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Contexts grid */
+.contexts-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 768px) {
+  .contexts-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .contexts-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* Context card */
 .context-card-wrapper:focus-visible {
   outline: none;
 }
+
 .context-card-wrapper:focus-visible > :deep(.card) {
   box-shadow: 0 0 0 2px var(--bg-primary), 0 0 0 4px var(--color-primary-500);
 }
 
-@media (min-width: 768px) {
-  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.context-card-item {
+  height: 100%;
+  cursor: pointer;
+  border-left-width: 4px;
+  transition: box-shadow var(--transition-normal);
 }
 
-@media (min-width: 1024px) {
-  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.context-card-item:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.card-badges {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--spacing-4);
+}
+
+.card-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-2);
+}
+
+/* Override fields */
+.override-list {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.override-list > * + * {
+  margin-top: var(--spacing-2);
+}
+
+.override-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.override-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  width: 3rem;
+}
+
+.override-value {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.override-fallback {
+  color: var(--text-tertiary);
+  font-style: italic;
 }
 </style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -8,7 +8,7 @@ const authStore = useAuthStore()
 
 <template>
   <div class="home-view">
-    <div class="container container-md">
+    <div class="container container-lg">
       <div class="hero">
         <h1 class="hero-title">{{ t('app.name') }}</h1>
         <p class="hero-tagline">{{ t('app.tagline') }}</p>
@@ -60,7 +60,7 @@ const authStore = useAuthStore()
 
 <style scoped>
 .home-view {
-  padding: var(--spacing-12) 0;
+  padding: var(--spacing-8) 0;
 }
 
 .hero {

--- a/frontend/src/views/NotFoundView.vue
+++ b/frontend/src/views/NotFoundView.vue
@@ -19,7 +19,7 @@ const { t } = useI18n()
 
 <style scoped>
 .not-found-view {
-  padding: var(--spacing-12) 0;
+  padding: var(--spacing-8) 0;
   min-height: 60vh;
   display: flex;
   align-items: center;

--- a/frontend/src/views/OAuthConsentView.vue
+++ b/frontend/src/views/OAuthConsentView.vue
@@ -190,13 +190,6 @@ async function handleDecision(decision: 'allow' | 'deny') {
   background-color: var(--bg-secondary);
 }
 
-.container-sm {
-  max-width: 480px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 0 var(--spacing-4);
-}
-
 .client-logo {
   width: 80px;
   height: 80px;

--- a/frontend/src/views/ProfileEditView.vue
+++ b/frontend/src/views/ProfileEditView.vue
@@ -47,11 +47,11 @@ onMounted(async () => {
     // Ensure we have the latest profile data
     const profile = await profileService.get(authStore.userId)
     profileStore.setProfile(profile)
-    
+
     // Also fetch identity names for the manager
     const names = await profileService.getNames(authStore.userId)
     profileStore.setIdentityNames(names)
-    
+
     // Populate form
     form.legal_name = profile.legal_name || ''
     form.primary_email = profile.primary_email
@@ -66,7 +66,7 @@ onMounted(async () => {
 
 const handleSave = async () => {
   if (!authStore.userId) return
-  
+
   isSaving.value = true
   error.value = null
 
@@ -80,7 +80,7 @@ const handleSave = async () => {
 
     const updatedProfile = await profileService.update(authStore.userId, updates)
     profileStore.setProfile(updatedProfile)
-    
+
     router.back()
   } catch (err) {
     error.value = getErrorMessage(err)
@@ -95,27 +95,27 @@ const handleCancel = () => {
 </script>
 
 <template>
-  <div class="profile-edit-view">
-    <div class="container container-sm">
-      <div class="page-header mb-6">
-        <h1 class="text-2xl font-bold text-gray-900">{{ t('profile.editProfile') }}</h1>
+  <div class="page-view">
+    <div class="container container-lg">
+      <div class="page-header">
+        <h1 class="page-title">{{ t('profile.editProfile') }}</h1>
       </div>
 
-      <div v-if="isLoading" class="loading-state text-center py-12">
-        <div class="spinner spinner-lg mx-auto"></div>
-        <p class="mt-4 text-gray-500">{{ t('common.loading') }}</p>
+      <div v-if="isLoading" class="loading-container">
+        <div class="spinner spinner-lg"></div>
+        <p class="loading-text">{{ t('common.loading') }}</p>
       </div>
 
-      <div v-else class="edit-content space-y-6">
-        <div v-if="error" class="alert alert-error mb-6">
+      <div v-else class="edit-content">
+        <div v-if="error" class="alert alert-error edit-error">
           {{ error }}
         </div>
 
         <BaseCard>
           <template #header>
-            <h2 class="text-lg font-semibold">Base Information</h2>
+            <h2 class="card-heading">Base Information</h2>
           </template>
-          
+
           <form @submit.prevent="handleSave">
             <BaseInput
               v-model="form.legal_name"
@@ -148,7 +148,7 @@ const handleCancel = () => {
               :options="languageOptions"
             />
 
-            <div class="form-actions mt-8 flex justify-end gap-4">
+            <div class="form-actions">
               <BaseButton variant="ghost" @click="handleCancel" :disabled="isSaving">
                 {{ t('common.cancel') }}
               </BaseButton>
@@ -168,19 +168,39 @@ const handleCancel = () => {
 </template>
 
 <style scoped>
-.profile-edit-view {
-  padding: var(--spacing-8) 0;
+/* Header */
+/* Loading */
+.loading-container {
+  text-align: center;
+  padding: var(--spacing-12) 0;
 }
 
-.container-sm {
-  max-width: 640px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: var(--spacing-4);
-  padding-right: var(--spacing-4);
+.loading-text {
+  margin-top: var(--spacing-4);
+  color: var(--text-secondary);
 }
 
-.space-y-6 > * + * {
-  margin-top: 1.5rem;
+/* Content */
+.edit-content > * + * {
+  margin-top: var(--spacing-6);
+}
+
+.edit-error {
+  margin-bottom: var(--spacing-6);
+}
+
+/* Card heading */
+.card-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+/* Form actions */
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-4);
+  margin-top: 2rem;
 }
 </style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -36,7 +36,7 @@ onMounted(async () => {
       profileService.getNames(authStore.userId),
       contextService.list(authStore.userId)
     ])
-    
+
     profileStore.setProfile(profile)
     profileStore.setIdentityNames(names)
     profileStore.setContexts(contexts)
@@ -61,38 +61,38 @@ const navigateToCreateContext = () => {
 </script>
 
 <template>
-  <div class="profile-view">
-    <div class="container container-md">
+  <div class="page-view">
+    <div class="container container-lg">
       <div v-if="isLoading" class="loading-state">
         <div class="spinner spinner-lg"></div>
-        <p class="mt-4 text-secondary">{{ t('common.loading') }}</p>
+        <p class="loading-text">{{ t('common.loading') }}</p>
       </div>
 
-      <div v-else-if="error" class="alert alert-error mb-6">
+      <div v-else-if="error" class="alert alert-error alert-spaced">
         {{ error }}
       </div>
 
       <div v-else-if="profileStore.profile" class="profile-content">
         <!-- Header Section -->
-        <div class="profile-header mb-8 text-center">
-          <div class="avatar-lg mx-auto mb-4 bg-primary-100 text-primary-700 flex items-center justify-center rounded-full">
+        <div class="profile-header">
+          <div class="profile-avatar">
             {{ initials }}
           </div>
-          <h1 class="text-3xl font-bold text-gray-900 mb-1">{{ profileStore.displayName }}</h1>
-          <p class="text-gray-500 mb-4">{{ profileStore.profile.primary_email }}</p>
+          <h1 class="profile-name">{{ profileStore.displayName }}</h1>
+          <p class="profile-email">{{ profileStore.profile.primary_email }}</p>
           <BaseButton variant="secondary" @click="navigateToEdit">
             {{ t('profile.editProfile') }}
           </BaseButton>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="profile-grid">
           <!-- Base Information -->
           <BaseCard>
             <template #header>
-              <h2 class="text-lg font-semibold">{{ t('profile.baseProfile') }}</h2>
+              <h2 class="card-heading">{{ t('profile.baseProfile') }}</h2>
             </template>
-            
-            <div class="space-y-4">
+
+            <div class="fields-list">
               <div class="field-group">
                 <label class="field-label">{{ t('auth.accountType.label') }}</label>
                 <div>
@@ -132,34 +132,34 @@ const navigateToCreateContext = () => {
           <!-- Identity Names -->
           <BaseCard>
             <template #header>
-              <div class="flex justify-between items-center">
-                <h2 class="text-lg font-semibold">Identity Names</h2>
+              <div class="card-header-row">
+                <h2 class="card-heading">Identity Names</h2>
                 <BaseButton variant="ghost" size="sm" @click="navigateToEdit">+ Add</BaseButton>
               </div>
             </template>
-            
-            <div v-if="profileStore.identityNames.length === 0" class="text-gray-500 text-center py-4">
+
+            <div v-if="profileStore.identityNames.length === 0" class="empty-names">
               No additional names configured.
             </div>
 
-            <div v-else class="space-y-4">
+            <div v-else class="fields-list">
               <div
                 v-for="name in profileStore.identityNames"
                 :key="name.id"
-                class="name-item pb-4 border-b border-gray-100 last:border-0 last:pb-0"
+                class="name-item"
               >
-                <div class="flex items-center gap-2 mb-2">
+                <div class="name-badges">
                   <BaseBadge variant="primary" size="sm">{{ name.name_type }}</BaseBadge>
                   <BaseBadge v-if="name.is_primary" variant="success" size="sm">Primary</BaseBadge>
                 </div>
-                <div class="flex flex-wrap gap-x-4 gap-y-1">
+                <div class="name-languages">
                   <div
                     v-for="(value, lang) in name.name_value"
                     :key="lang"
-                    class="text-sm"
+                    class="name-lang-entry"
                   >
-                    <span class="font-medium text-gray-500 uppercase text-xs mr-1">{{ lang }}</span>
-                    <span class="text-gray-900">{{ value }}</span>
+                    <span class="name-lang-code">{{ lang }}</span>
+                    <span class="name-lang-value">{{ value }}</span>
                   </div>
                 </div>
               </div>
@@ -167,39 +167,39 @@ const navigateToCreateContext = () => {
           </BaseCard>
 
           <!-- Identity Contexts -->
-          <BaseCard class="md:col-span-2">
+          <BaseCard class="col-span-full">
             <template #header>
-              <div class="flex justify-between items-center">
-                <h2 class="text-lg font-semibold">Identity Contexts</h2>
+              <div class="card-header-row">
+                <h2 class="card-heading">Identity Contexts</h2>
                 <BaseButton variant="ghost" size="sm" @click="navigateToCreateContext">+ Create</BaseButton>
               </div>
             </template>
 
-            <div v-if="profileStore.contexts.length === 0" class="text-center py-8">
-              <div class="text-gray-500 mb-4">No contexts yet. Create one to separate your identities.</div>
+            <div v-if="profileStore.contexts.length === 0" class="empty-contexts">
+              <div class="empty-contexts-text">No contexts yet. Create one to separate your identities.</div>
               <BaseButton variant="primary" @click="navigateToCreateContext">Create Context</BaseButton>
             </div>
 
-            <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div v-else class="contexts-cards">
               <div
                 v-for="context in profileStore.contexts"
                 :key="context.id"
-                class="context-card p-4 border border-gray-200 rounded-lg hover:border-primary-300 hover:shadow-sm transition-all cursor-pointer bg-white"
+                class="context-card"
                 @click="router.push({ name: 'context-detail', params: { id: context.id } })"
               >
-                <div class="flex items-start justify-between mb-2">
+                <div class="context-card-header">
                   <BaseBadge :variant="context.context_type">
                     {{ CONTEXT_TYPE_META[context.context_type]?.label || context.context_type }}
                   </BaseBadge>
-                  <span class="text-gray-400">→</span>
+                  <span class="context-card-arrow">-></span>
                 </div>
-                <h3 class="font-medium text-gray-900 mb-1">{{ context.context_name }}</h3>
-                <p class="text-sm text-gray-500 line-clamp-2">{{ context.bio || 'Inherited bio' }}</p>
+                <h3 class="context-card-title">{{ context.context_name }}</h3>
+                <p class="context-card-bio">{{ context.bio || 'Inherited bio' }}</p>
               </div>
             </div>
-            
+
             <template #footer>
-              <div class="text-center">
+              <div class="card-footer-center">
                 <BaseButton variant="ghost" @click="navigateToContexts">View All Contexts</BaseButton>
               </div>
             </template>
@@ -211,23 +211,97 @@ const navigateToCreateContext = () => {
 </template>
 
 <style scoped>
-.profile-view {
-  padding: var(--spacing-8) 0;
+/* Loading state */
+.loading-state {
+  text-align: center;
+  padding: var(--spacing-12) 0;
 }
 
-.avatar-lg {
+.loading-text {
+  margin-top: var(--spacing-4);
+  color: var(--text-secondary);
+}
+
+.alert-spaced {
+  margin-bottom: var(--spacing-6);
+}
+
+/* Profile header */
+.profile-header {
+  text-align: center;
+  margin-bottom: var(--spacing-8);
+}
+
+.profile-avatar {
   width: 80px;
   height: 80px;
   font-size: 2rem;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
+  margin: 0 auto var(--spacing-4);
+  background-color: var(--color-primary-100);
+  color: var(--color-primary-700);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+}
+
+.profile-name {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-1);
+}
+
+.profile-email {
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-4);
+}
+
+/* Profile grid */
+.profile-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-6);
+}
+
+@media (min-width: 768px) {
+  .profile-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .col-span-full {
+    grid-column: span 2 / span 2;
+  }
+}
+
+/* Card elements */
+.card-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.card-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.card-footer-center {
+  text-align: center;
+}
+
+/* Field display */
+.fields-list > * + * {
+  margin-top: var(--spacing-4);
 }
 
 .field-label {
   font-size: var(--font-size-xs);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-gray-500);
+  color: var(--text-tertiary);
   margin-bottom: var(--spacing-1);
 }
 
@@ -236,66 +310,119 @@ const navigateToCreateContext = () => {
   color: var(--text-primary);
 }
 
-/* Utility classes that might be missing if Tailwind isn't fully set up */
-.grid { display: grid; }
-.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.gap-6 { gap: 1.5rem; }
-.gap-4 { gap: 1rem; }
-.space-y-4 > * + * { margin-top: 1rem; }
-.text-center { text-align: center; }
-.mx-auto { margin-left: auto; margin-right: auto; }
-.mb-8 { margin-bottom: 2rem; }
-.mb-6 { margin-bottom: 1.5rem; }
-.mb-4 { margin-bottom: 1rem; }
-.mb-2 { margin-bottom: 0.5rem; }
-.mb-1 { margin-bottom: 0.25rem; }
-.text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
-.font-bold { font-weight: 700; }
-.font-semibold { font-weight: 600; }
-.font-medium { font-weight: 500; }
-.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-.text-xs { font-size: 0.75rem; line-height: 1rem; }
-.text-gray-900 { color: var(--text-primary); }
-.text-gray-500 { color: var(--text-secondary); }
-.text-gray-400 { color: var(--text-tertiary); }
-.bg-primary-100 { background-color: var(--color-primary-100); }
-.text-primary-700 { color: var(--color-primary-700); }
-.rounded-full { border-radius: 9999px; }
-.flex { display: flex; }
-.items-center { align-items: center; }
-.justify-center { justify-content: center; }
-.justify-between { justify-content: space-between; }
-.flex-wrap { flex-wrap: wrap; }
-.gap-x-4 { column-gap: 1rem; }
-.gap-y-1 { row-gap: 0.25rem; }
-.uppercase { text-transform: uppercase; }
-.mr-1 { margin-right: 0.25rem; }
-.p-4 { padding: 1rem; }
-.border { border-width: 1px; }
-.border-gray-200 { border-color: var(--border-primary); }
-.border-gray-100 { border-color: var(--border-primary); }
-.border-b { border-bottom-width: 1px; }
-.rounded-lg { border-radius: 0.5rem; }
-.bg-white { background-color: var(--bg-secondary); }
-.cursor-pointer { cursor: pointer; }
-.line-clamp-2 {
+/* Identity names */
+.empty-names {
+  color: var(--text-secondary);
+  text-align: center;
+  padding: var(--spacing-4) 0;
+}
+
+.name-item {
+  padding-bottom: var(--spacing-4);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.name-item:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.name-badges {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.name-languages {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: var(--spacing-4);
+  row-gap: var(--spacing-1);
+}
+
+.name-lang-entry {
+  font-size: var(--font-size-sm);
+}
+
+.name-lang-code {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  margin-right: var(--spacing-1);
+}
+
+.name-lang-value {
+  color: var(--text-primary);
+}
+
+/* Context cards */
+.empty-contexts {
+  text-align: center;
+  padding: var(--spacing-8) 0;
+}
+
+.empty-contexts-text {
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-4);
+}
+
+.contexts-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-4);
+}
+
+@media (min-width: 640px) {
+  .contexts-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .contexts-cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.context-card {
+  padding: var(--spacing-4);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  background-color: var(--bg-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.context-card:hover {
+  border-color: var(--color-primary-300);
+  box-shadow: var(--shadow-sm);
+}
+
+.context-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-2);
+}
+
+.context-card-arrow {
+  color: var(--text-tertiary);
+}
+
+.context-card-title {
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-1);
+}
+
+.context-card-bio {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow: hidden;
-}
-
-@media (min-width: 768px) {
-  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .md\:col-span-2 { grid-column: span 2 / span 2; }
-}
-
-@media (min-width: 640px) {
-  .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
-
-@media (min-width: 1024px) {
-  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 </style>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -106,7 +106,7 @@ async function handleDeleteAccount() {
 
 <template>
   <div class="settings-view">
-    <div class="container container-md">
+    <div class="container container-lg">
       <div class="page-header">
         <h1 class="page-title">{{ t('settings.title') }}</h1>
         <p class="page-description">{{ t('settings.description') }}</p>
@@ -303,7 +303,7 @@ async function handleDeleteAccount() {
 
 <style scoped>
 .settings-view {
-  padding: var(--spacing-6) 0;
+  padding: var(--spacing-8) 0;
 }
 
 .settings-section {

--- a/frontend/src/views/admin/AdminAuditVerifyView.vue
+++ b/frontend/src/views/admin/AdminAuditVerifyView.vue
@@ -52,7 +52,7 @@ function goBack() {
 
 <template>
   <div class="admin-audit-verify-view">
-    <div class="container container-md">
+    <div class="container container-lg">
       <button type="button" class="back-link" @click="goBack">
         <ArrowLeftIcon class="back-icon" />
         {{ t('audit.verify.backToAdmin') }}
@@ -69,6 +69,7 @@ function goBack() {
           <div class="control-row">
             <BaseInput
               v-model="verifyLimit"
+              id="verify_limit"
               type="number"
               :label="t('audit.verify.entriesLabel')"
               :hint="t('audit.verify.entriesHint')"
@@ -129,10 +130,6 @@ function goBack() {
   padding: var(--spacing-8) 0;
 }
 
-.container-md {
-  max-width: 720px;
-}
-
 .back-link {
   display: inline-flex;
   align-items: center;
@@ -154,23 +151,6 @@ function goBack() {
 .back-icon {
   width: 16px;
   height: 16px;
-}
-
-.page-header {
-  margin-bottom: var(--spacing-6);
-}
-
-.page-title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--text-primary);
-  margin: 0 0 var(--spacing-1);
-}
-
-.page-description {
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
-  margin: 0;
 }
 
 .verify-controls {

--- a/frontend/src/views/admin/AdminOAuthClientCreateView.vue
+++ b/frontend/src/views/admin/AdminOAuthClientCreateView.vue
@@ -46,7 +46,7 @@ function goBack(): void {
 
 <template>
   <div class="admin-oauth-client-create-view">
-    <div class="container container-md">
+    <div class="container container-lg">
       <button type="button" class="back-link" @click="goBack">
         <ArrowLeftIcon class="back-icon" />
         Back to OAuth Clients
@@ -87,10 +87,6 @@ function goBack(): void {
   padding: var(--spacing-8) 0;
 }
 
-.container-md {
-  max-width: 640px;
-}
-
 .back-link {
   display: inline-flex;
   align-items: center;
@@ -113,22 +109,6 @@ function goBack(): void {
 .back-icon {
   width: 16px;
   height: 16px;
-}
-
-.page-header {
-  margin-bottom: var(--spacing-6);
-}
-
-.page-title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--text-primary);
-  margin: 0 0 var(--spacing-1) 0;
-}
-
-.page-description {
-  color: var(--text-secondary);
-  margin: 0;
 }
 
 .alert-error {

--- a/frontend/src/views/admin/AdminOAuthClientEditView.vue
+++ b/frontend/src/views/admin/AdminOAuthClientEditView.vue
@@ -53,7 +53,7 @@ function goBack(): void {
 
 <template>
   <div class="admin-oauth-client-edit-view">
-    <div class="container container-md">
+    <div class="container container-lg">
       <button type="button" class="back-link" @click="goBack">
         <ArrowLeftIcon class="back-icon" />
         Back to OAuth Clients
@@ -99,10 +99,6 @@ function goBack(): void {
   padding: var(--spacing-8) 0;
 }
 
-.container-md {
-  max-width: 640px;
-}
-
 .back-link {
   display: inline-flex;
   align-items: center;
@@ -125,22 +121,6 @@ function goBack(): void {
 .back-icon {
   width: 16px;
   height: 16px;
-}
-
-.page-header {
-  margin-bottom: var(--spacing-6);
-}
-
-.page-title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--text-primary);
-  margin: 0 0 var(--spacing-1) 0;
-}
-
-.page-description {
-  color: var(--text-secondary);
-  margin: 0;
 }
 
 .loading-state {

--- a/frontend/src/views/admin/AdminOAuthClientsView.vue
+++ b/frontend/src/views/admin/AdminOAuthClientsView.vue
@@ -189,18 +189,6 @@ async function toggleInactive(): Promise<void> {
   min-width: 200px;
 }
 
-.page-title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--text-primary);
-  margin: 0 0 var(--spacing-1) 0;
-}
-
-.page-description {
-  color: var(--text-secondary);
-  margin: 0;
-}
-
 .btn-icon {
   width: 20px;
   height: 20px;


### PR DESCRIPTION
All regular app pages now use `container-lg` (1024px) for uniform viewport width
Page titles and descriptions use global `.page-title` / `.page-description` classes from layout.css
Removed duplicate scoped style overrides that conflicted with the global layout system


## Test
- [x] Visually inspect all app pages for consistent container width and title sizing
- [x] Verify auth-flow pages retain narrower centered layout
- [x] Check dark mode rendering on all modified views
- [x] Run `npm run build` to confirm no build errors