### PR TITLE
Add admin UI for listing and purging soft-deleted users

### DIFF
--- a/backend/src/api/v1/endpoints/admin_users.py
+++ b/backend/src/api/v1/endpoints/admin_users.py
@@ -1,0 +1,127 @@
+"""
+Admin User Management Endpoints
+
+REST API endpoints for managing user accounts.
+All endpoints require admin privileges.
+"""
+
+from fastapi import APIRouter, Depends, Request, status, Query
+from sqlalchemy.orm import Session
+
+from src.core.database import get_db
+from src.api.dependencies.auth import require_admin
+from src.models.auth import AuthUser
+from src.models.audit import AuditEventType, AuditOperation
+from src.repositories.auth_repository import AuthRepository
+from src.repositories.context_repository import ContextRepository
+from src.repositories.oauth_repository import OAuthRepository
+from src.repositories.profile_repository import ProfileRepository
+from src.repositories.audit_repository import AuditRepository
+from src.services.audit_service import AuditService
+from src.services.privacy_service import PrivacyService
+from src.schemas.admin_users import (
+    SoftDeletedUserResponse,
+    SoftDeletedUserListResponse,
+    PurgeExpiredResponse,
+)
+
+router = APIRouter()
+
+
+def get_privacy_service(db: Session = Depends(get_db)) -> PrivacyService:
+    """Dependency to get PrivacyService instance."""
+    profile_repo = ProfileRepository(db)
+    context_repo = ContextRepository(db)
+    auth_repo = AuthRepository(db)
+    oauth_repo = OAuthRepository(db)
+    audit_repo = AuditRepository(db)
+    audit_service = AuditService(audit_repo)
+    return PrivacyService(
+        profile_repo=profile_repo,
+        context_repo=context_repo,
+        auth_repo=auth_repo,
+        oauth_repo=oauth_repo,
+        audit_service=audit_service,
+    )
+
+
+def get_audit_service(db: Session = Depends(get_db)) -> AuditService:
+    """Dependency to get AuditService instance for admin audit logging."""
+    return AuditService(AuditRepository(db))
+
+
+@router.get(
+    "/users/soft-deleted",
+    response_model=SoftDeletedUserListResponse,
+    summary="List Soft-Deleted Users",
+    description=(
+        "List all soft-deleted user accounts with pagination. "
+        "Requires admin privileges."
+    ),
+)
+def list_soft_deleted_users(
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page"),
+    admin: AuthUser = Depends(require_admin),
+    service: PrivacyService = Depends(get_privacy_service),
+):
+    """List all soft-deleted user accounts."""
+    offset = (page - 1) * page_size
+    users, total = service.list_soft_deleted_users(
+        offset=offset, limit=page_size
+    )
+    return SoftDeletedUserListResponse(
+        users=[
+            SoftDeletedUserResponse(
+                user_id=str(u.user_id),
+                email=u.email,
+                is_email_verified=u.is_email_verified,
+                is_admin=u.is_admin,
+                deleted_at=u.deleted_at,
+                created_at=u.created_at,
+            )
+            for u in users
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.post(
+    "/users/purge-expired",
+    response_model=PurgeExpiredResponse,
+    summary="Purge Expired Soft-Deleted Users",
+    description=(
+        "Permanently delete all soft-deleted user accounts whose 30-day "
+        "retention period has expired. This is a destructive, irreversible "
+        "operation. Requires admin privileges."
+    ),
+)
+def purge_expired_users(
+    request: Request,
+    admin: AuthUser = Depends(require_admin),
+    service: PrivacyService = Depends(get_privacy_service),
+    audit_service: AuditService = Depends(get_audit_service),
+):
+    """Purge all soft-deleted accounts past the retention period."""
+    purged_count = service.purge_expired_accounts()
+
+    # Audit log the admin-initiated purge trigger
+    audit_service.log_event(
+        event_type=AuditEventType.account_permanently_purged,
+        user_id=None,
+        actor_id=admin.user_id,
+        resource_type="account",
+        resource_id="admin_purge_trigger",
+        operation=AuditOperation.delete,
+        changes={
+            "admin_initiated": True,
+            "purged_count": purged_count,
+        },
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+        legal_basis="gdpr_art_17_admin_purge",
+    )
+
+    return PurgeExpiredResponse(purged_count=purged_count)

--- a/backend/src/api/v1/router.py
+++ b/backend/src/api/v1/router.py
@@ -53,6 +53,10 @@ api_router.include_router(oauth.router, prefix="/oauth", tags=["OAuth 2.1"])
 from src.api.v1.endpoints import admin_oauth
 api_router.include_router(admin_oauth.router, prefix="/admin/oauth", tags=["Admin - OAuth"])
 
+# Include Admin User Management endpoints (requires admin privileges)
+from src.api.v1.endpoints import admin_users
+api_router.include_router(admin_users.router, prefix="/admin", tags=["Admin - Users"])
+
 # Include Audit endpoints (Phase 4: Privacy Features)
 from src.api.v1.endpoints import audit
 api_router.include_router(audit.router, prefix="/audit", tags=["Audit"])

--- a/backend/src/repositories/auth_repository.py
+++ b/backend/src/repositories/auth_repository.py
@@ -8,7 +8,7 @@ Handles CRUD operations and authentication-specific queries.
 from datetime import datetime, timezone, timedelta
 from typing import List, Optional
 from sqlalchemy.orm import Session
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from src.models.auth import AuthUser
 
@@ -456,6 +456,37 @@ class AuthRepository:
         )
         result = self.db.execute(stmt)
         return list(result.scalars().all())
+
+    def get_all_soft_deleted_users(
+        self, offset: int = 0, limit: int = 20
+    ) -> List[AuthUser]:
+        """
+        Get all soft-deleted users with pagination.
+
+        Args:
+            offset: Number of records to skip
+            limit: Maximum number of records to return
+
+        Returns:
+            List of soft-deleted AuthUser records ordered by deletion date
+        """
+        stmt = (
+            select(AuthUser)
+            .where(AuthUser.deleted_at.isnot(None))
+            .order_by(AuthUser.deleted_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    def count_soft_deleted_users(self) -> int:
+        """Count all soft-deleted users."""
+        stmt = select(func.count()).select_from(AuthUser).where(
+            AuthUser.deleted_at.isnot(None)
+        )
+        result = self.db.execute(stmt)
+        return result.scalar() or 0
 
     def hard_delete(self, user_id: str) -> bool:
         """

--- a/backend/src/schemas/admin_users.py
+++ b/backend/src/schemas/admin_users.py
@@ -1,0 +1,38 @@
+"""
+Admin User Management Schemas
+
+Pydantic models for admin user management endpoints.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SoftDeletedUserResponse(BaseModel):
+    """Response schema for a soft-deleted user."""
+
+    user_id: str
+    email: str
+    is_email_verified: bool
+    is_admin: bool
+    deleted_at: datetime
+    created_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SoftDeletedUserListResponse(BaseModel):
+    """Paginated list of soft-deleted users."""
+
+    users: List[SoftDeletedUserResponse]
+    total: int
+    page: int = 1
+    page_size: int = 20
+
+
+class PurgeExpiredResponse(BaseModel):
+    """Response from purging expired soft-deleted accounts."""
+
+    purged_count: int

--- a/backend/src/services/privacy_service.py
+++ b/backend/src/services/privacy_service.py
@@ -456,3 +456,22 @@ class PrivacyService:
             retention_days,
         )
         return purged_count
+
+    def list_soft_deleted_users(
+        self, offset: int = 0, limit: int = 20
+    ) -> tuple:
+        """
+        List all soft-deleted users with pagination.
+
+        Args:
+            offset: Number of records to skip
+            limit: Maximum number of records to return
+
+        Returns:
+            Tuple of (list of AuthUser, total count)
+        """
+        users = self.auth_repo.get_all_soft_deleted_users(
+            offset=offset, limit=limit
+        )
+        total = self.auth_repo.count_soft_deleted_users()
+        return users, total

--- a/backend/tests/integration/test_admin_user_endpoints.py
+++ b/backend/tests/integration/test_admin_user_endpoints.py
@@ -1,0 +1,221 @@
+"""
+Integration tests for admin user management endpoints.
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.main import app
+from src.core.database import get_db
+from src.models.auth import AuthUser
+from src.core.security import create_access_token
+
+
+class TestAdminUserEndpoints:
+    """Integration tests for admin user management endpoints."""
+
+    @pytest.fixture
+    def client(self, db_session: Session):
+        """Create a test client with database dependency override."""
+        def override_get_db():
+            try:
+                yield db_session
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = override_get_db
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def admin_user(self, db_session: Session):
+        """Create an admin user for testing."""
+        from src.models.profile import BaseProfile, AccountType
+
+        profile = BaseProfile(
+            user_id="00000000-0000-0000-0000-000000000080",
+            account_type=AccountType.verified,
+            primary_email="admin.purge@example.com",
+            preferred_language="en",
+        )
+        db_session.add(profile)
+        db_session.commit()
+
+        admin = AuthUser(
+            user_id="00000000-0000-0000-0000-000000000080",
+            email="admin.purge@example.com",
+            password_hash="$argon2id$v=19$m=65536,t=3,p=4$FAKE_HASH",
+            is_email_verified=True,
+            is_admin=True,
+        )
+        db_session.add(admin)
+        db_session.commit()
+        return admin
+
+    @pytest.fixture
+    def regular_user(self, db_session: Session):
+        """Create a regular (non-admin) user for testing."""
+        from src.models.profile import BaseProfile, AccountType
+
+        profile = BaseProfile(
+            user_id="00000000-0000-0000-0000-000000000081",
+            account_type=AccountType.verified,
+            primary_email="regular.purge@example.com",
+            preferred_language="en",
+        )
+        db_session.add(profile)
+        db_session.commit()
+
+        user = AuthUser(
+            user_id="00000000-0000-0000-0000-000000000081",
+            email="regular.purge@example.com",
+            password_hash="$argon2id$v=19$m=65536,t=3,p=4$FAKE_HASH",
+            is_email_verified=True,
+            is_admin=False,
+        )
+        db_session.add(user)
+        db_session.commit()
+        return user
+
+    @pytest.fixture
+    def admin_token(self, admin_user):
+        """Generate access token for admin user."""
+        return create_access_token(
+            user_id=str(admin_user.user_id),
+            email=admin_user.email,
+            account_type="verified",
+        )
+
+    @pytest.fixture
+    def regular_token(self, regular_user):
+        """Generate access token for regular user."""
+        return create_access_token(
+            user_id=str(regular_user.user_id),
+            email=regular_user.email,
+            account_type="verified",
+        )
+
+    @pytest.fixture
+    def soft_deleted_user(self, db_session: Session):
+        """Create a soft-deleted user for testing."""
+        from src.models.profile import BaseProfile, AccountType
+
+        profile = BaseProfile(
+            user_id="00000000-0000-0000-0000-000000000082",
+            account_type=AccountType.verified,
+            primary_email="deleted.user@example.com",
+            preferred_language="en",
+            deleted_at=datetime.now(timezone.utc) - timedelta(days=5),
+        )
+        db_session.add(profile)
+        db_session.commit()
+
+        user = AuthUser(
+            user_id="00000000-0000-0000-0000-000000000082",
+            email="deleted.user@example.com",
+            password_hash="$argon2id$v=19$m=65536,t=3,p=4$FAKE_HASH",
+            is_email_verified=True,
+            is_admin=False,
+            deleted_at=datetime.now(timezone.utc) - timedelta(days=5),
+        )
+        db_session.add(user)
+        db_session.commit()
+        return user
+
+    # =========================================================================
+    # GET /api/v1/admin/users/soft-deleted
+    # =========================================================================
+
+    def test_list_soft_deleted_users_as_admin(
+        self, client: TestClient, admin_token: str, soft_deleted_user
+    ):
+        """Admin can list soft-deleted users."""
+        response = client.get(
+            "/api/v1/admin/users/soft-deleted",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "users" in data
+        assert "total" in data
+        assert data["total"] >= 1
+        # Verify the soft-deleted user appears in the list
+        emails = [u["email"] for u in data["users"]]
+        assert "deleted.user@example.com" in emails
+
+    def test_list_soft_deleted_users_empty(
+        self, client: TestClient, admin_token: str
+    ):
+        """Admin gets empty list when no soft-deleted users exist."""
+        response = client.get(
+            "/api/v1/admin/users/soft-deleted",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["users"] == []
+        assert data["total"] == 0
+
+    def test_list_soft_deleted_users_as_non_admin(
+        self, client: TestClient, regular_token: str
+    ):
+        """Non-admin users cannot list soft-deleted users."""
+        response = client.get(
+            "/api/v1/admin/users/soft-deleted",
+            headers={"Authorization": f"Bearer {regular_token}"},
+        )
+        assert response.status_code == 403
+
+    def test_list_soft_deleted_users_unauthenticated(
+        self, client: TestClient
+    ):
+        """Unauthenticated requests are rejected."""
+        response = client.get("/api/v1/admin/users/soft-deleted")
+        assert response.status_code == 401
+
+    def test_list_soft_deleted_users_excludes_active(
+        self, client: TestClient, admin_token: str,
+        soft_deleted_user, admin_user
+    ):
+        """Active users do not appear in the soft-deleted list."""
+        response = client.get(
+            "/api/v1/admin/users/soft-deleted",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        data = response.json()
+        user_ids = [u["user_id"] for u in data["users"]]
+        assert str(admin_user.user_id) not in user_ids
+
+    # =========================================================================
+    # POST /api/v1/admin/users/purge-expired
+    # =========================================================================
+
+    def test_purge_expired_as_admin_none_expired(
+        self, client: TestClient, admin_token: str, soft_deleted_user
+    ):
+        """Admin can trigger purge; returns 0 when no users are expired."""
+        # soft_deleted_user was deleted 5 days ago, not yet expired (30 days)
+        response = client.post(
+            "/api/v1/admin/users/purge-expired",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["purged_count"] == 0
+
+    def test_purge_expired_as_non_admin(
+        self, client: TestClient, regular_token: str
+    ):
+        """Non-admin users cannot trigger purge."""
+        response = client.post(
+            "/api/v1/admin/users/purge-expired",
+            headers={"Authorization": f"Bearer {regular_token}"},
+        )
+        assert response.status_code == 403
+
+    def test_purge_expired_unauthenticated(self, client: TestClient):
+        """Unauthenticated requests are rejected."""
+        response = client.post("/api/v1/admin/users/purge-expired")
+        assert response.status_code == 401

--- a/backend/tests/unit/test_admin_user_purge.py
+++ b/backend/tests/unit/test_admin_user_purge.py
@@ -1,0 +1,158 @@
+"""
+Unit Tests for Admin User Purge
+
+Tests the list_soft_deleted_users and purge_expired_accounts service methods
+with mocked repositories.
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import Mock
+from uuid import uuid4
+
+from src.services.privacy_service import PrivacyService
+
+
+@pytest.fixture
+def mock_profile_repo():
+    return Mock()
+
+
+@pytest.fixture
+def mock_context_repo():
+    return Mock()
+
+
+@pytest.fixture
+def mock_auth_repo():
+    return Mock()
+
+
+@pytest.fixture
+def mock_oauth_repo():
+    return Mock()
+
+
+@pytest.fixture
+def mock_audit_service():
+    return Mock()
+
+
+@pytest.fixture
+def privacy_service(
+    mock_profile_repo,
+    mock_context_repo,
+    mock_auth_repo,
+    mock_oauth_repo,
+    mock_audit_service,
+):
+    return PrivacyService(
+        profile_repo=mock_profile_repo,
+        context_repo=mock_context_repo,
+        auth_repo=mock_auth_repo,
+        oauth_repo=mock_oauth_repo,
+        audit_service=mock_audit_service,
+    )
+
+
+class TestListSoftDeletedUsers:
+    """Tests for the list_soft_deleted_users service method."""
+
+    def test_returns_users_and_count(
+        self, privacy_service, mock_auth_repo
+    ):
+        """Service returns soft-deleted users with total count."""
+        user1 = Mock()
+        user1.user_id = uuid4()
+        user1.email = "deleted1@example.com"
+        user1.deleted_at = datetime.now(timezone.utc) - timedelta(days=5)
+
+        user2 = Mock()
+        user2.user_id = uuid4()
+        user2.email = "deleted2@example.com"
+        user2.deleted_at = datetime.now(timezone.utc) - timedelta(days=10)
+
+        mock_auth_repo.get_all_soft_deleted_users.return_value = [
+            user1, user2
+        ]
+        mock_auth_repo.count_soft_deleted_users.return_value = 2
+
+        users, total = privacy_service.list_soft_deleted_users(
+            offset=0, limit=20
+        )
+
+        assert len(users) == 2
+        assert total == 2
+        mock_auth_repo.get_all_soft_deleted_users.assert_called_once_with(
+            offset=0, limit=20
+        )
+        mock_auth_repo.count_soft_deleted_users.assert_called_once()
+
+    def test_returns_empty_when_no_deleted_users(
+        self, privacy_service, mock_auth_repo
+    ):
+        """Service returns empty list when no soft-deleted users exist."""
+        mock_auth_repo.get_all_soft_deleted_users.return_value = []
+        mock_auth_repo.count_soft_deleted_users.return_value = 0
+
+        users, total = privacy_service.list_soft_deleted_users(
+            offset=0, limit=20
+        )
+
+        assert len(users) == 0
+        assert total == 0
+
+    def test_pagination_parameters_forwarded(
+        self, privacy_service, mock_auth_repo
+    ):
+        """Service forwards offset and limit to the repository."""
+        mock_auth_repo.get_all_soft_deleted_users.return_value = []
+        mock_auth_repo.count_soft_deleted_users.return_value = 0
+
+        privacy_service.list_soft_deleted_users(offset=40, limit=10)
+
+        mock_auth_repo.get_all_soft_deleted_users.assert_called_once_with(
+            offset=40, limit=10
+        )
+
+
+class TestPurgeExpiredAccounts:
+    """Tests for the purge_expired_accounts service method."""
+
+    def test_purges_expired_users(
+        self, privacy_service, mock_auth_repo, mock_profile_repo,
+        mock_audit_service,
+    ):
+        """Service purges users whose retention period has expired."""
+        expired_user = Mock()
+        expired_user.user_id = uuid4()
+        expired_user.deleted_at = (
+            datetime.now(timezone.utc) - timedelta(days=35)
+        )
+
+        mock_auth_repo.get_expired_soft_deleted_users.return_value = [
+            expired_user
+        ]
+        mock_auth_repo.hard_delete.return_value = True
+        mock_profile_repo.hard_delete_profile.return_value = True
+
+        purged_count = privacy_service.purge_expired_accounts()
+
+        assert purged_count == 1
+        mock_profile_repo.hard_delete_profile.assert_called_once_with(
+            expired_user.user_id
+        )
+        mock_auth_repo.hard_delete.assert_called_once_with(
+            str(expired_user.user_id)
+        )
+
+    def test_returns_zero_when_none_expired(
+        self, privacy_service, mock_auth_repo
+    ):
+        """Service returns 0 when no accounts have expired."""
+        mock_auth_repo.get_expired_soft_deleted_users.return_value = []
+
+        purged_count = privacy_service.purge_expired_accounts()
+
+        assert purged_count == 0
+        mock_auth_repo.hard_delete.assert_not_called()

--- a/frontend/src/components/admin/SoftDeletedUserCard.vue
+++ b/frontend/src/components/admin/SoftDeletedUserCard.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { SoftDeletedUser } from "@/types";
+import BaseCard from "@/components/common/BaseCard.vue";
+import BaseBadge from "@/components/common/BaseBadge.vue";
+
+const RETENTION_DAYS = 30;
+
+const props = defineProps<{
+  user: SoftDeletedUser;
+}>();
+
+const deletedDate = computed(() => {
+  return new Date(props.user.deleted_at).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+});
+
+const daysRemaining = computed(() => {
+  const deletedAt = new Date(props.user.deleted_at);
+  const purgeDate = new Date(
+    deletedAt.getTime() + RETENTION_DAYS * 24 * 60 * 60 * 1000,
+  );
+  const now = new Date();
+  const diffMs = purgeDate.getTime() - now.getTime();
+  return Math.max(0, Math.ceil(diffMs / (24 * 60 * 60 * 1000)));
+});
+
+const isExpired = computed(() => daysRemaining.value <= 0);
+
+const urgencyVariant = computed<"error" | "warning" | "neutral">(() => {
+  if (isExpired.value || daysRemaining.value <= 5) return "error";
+  if (daysRemaining.value <= 15) return "warning";
+  return "neutral";
+});
+
+const truncatedId = computed(() => {
+  const id = props.user.user_id;
+  if (id.length > 13) {
+    return id.substring(0, 8) + "...";
+  }
+  return id;
+});
+</script>
+
+<template>
+  <BaseCard>
+    <div class="user-card">
+      <div class="user-header">
+        <div class="user-info">
+          <h3 class="user-email">{{ user.email }}</h3>
+          <code class="user-id" :title="user.user_id">{{ truncatedId }}</code>
+        </div>
+        <div class="user-badges">
+          <BaseBadge
+            :variant="user.is_email_verified ? 'success' : 'warning'"
+            size="sm"
+          >
+            {{ user.is_email_verified ? "Verified" : "Unverified" }}
+          </BaseBadge>
+          <BaseBadge v-if="user.is_admin" variant="info" size="sm">
+            Admin
+          </BaseBadge>
+          <BaseBadge :variant="urgencyVariant" size="sm">
+            {{ isExpired ? "Expired" : daysRemaining + "d remaining" }}
+          </BaseBadge>
+        </div>
+      </div>
+
+      <div class="user-meta">
+        <div class="meta-item">
+          <span class="meta-label">Deleted:</span>
+          <span class="meta-value">{{ deletedDate }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Status:</span>
+          <span class="meta-value" :class="{ 'text-expired': isExpired }">
+            {{ isExpired ? "Eligible for purge" : "Grace period active" }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </BaseCard>
+</template>
+
+<style scoped>
+.user-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.user-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-4);
+  flex-wrap: wrap;
+}
+
+.user-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.user-email {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.user-id {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  background-color: var(--bg-tertiary);
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--radius-sm);
+}
+
+.user-badges {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.user-meta {
+  display: flex;
+  gap: var(--spacing-6);
+  flex-wrap: wrap;
+  padding-top: var(--spacing-2);
+  border-top: 1px solid var(--border-primary);
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.meta-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+}
+
+.meta-value {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+}
+
+.text-expired {
+  color: var(--color-error-600);
+}
+</style>

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -151,6 +151,13 @@ async function handleLogout() {
             >
               {{ t("nav.adminAuditVerify") }}
             </router-link>
+            <router-link
+              to="/admin/users/soft-deleted"
+              class="admin-menu-item"
+              @click="closeAdminMenu"
+            >
+              {{ t("nav.adminSoftDeletedUsers") }}
+            </router-link>
           </div>
         </Transition>
       </div>
@@ -264,6 +271,12 @@ async function handleLogout() {
                   class="mobile-nav-link mobile-nav-sub"
                 >
                   {{ t("nav.adminAuditVerify") }}
+                </router-link>
+                <router-link
+                  to="/admin/users/soft-deleted"
+                  class="mobile-nav-link mobile-nav-sub"
+                >
+                  {{ t("nav.adminSoftDeletedUsers") }}
                 </router-link>
               </div>
             </Transition>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -12,6 +12,7 @@
     "admin": "Admin",
     "adminOAuthClients": "OAuth Clients",
     "adminAuditVerify": "Audit Integrity",
+    "adminSoftDeletedUsers": "Deleted Users",
     "login": "Login",
     "register": "Register",
     "logout": "Logout"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -12,6 +12,7 @@
     "admin": "Admin",
     "adminOAuthClients": "Client OAuth",
     "adminAuditVerify": "Integrita audit",
+    "adminSoftDeletedUsers": "Utenti eliminati",
     "login": "Accedi",
     "register": "Registrati",
     "logout": "Esci"

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -231,6 +231,21 @@ const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "/admin/users/soft-deleted",
+    name: "admin-soft-deleted-users",
+    component: () =>
+      import("@/views/admin/AdminSoftDeletedUsersView.vue"),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: true,
+      title: "Soft-Deleted Users",
+      breadcrumb: {
+        parent: "/admin/oauth/clients",
+        parentLabel: "nav.adminOAuthClients",
+      },
+    },
+  },
+  {
     path: "/:pathMatch(.*)*",
     name: "not-found",
     component: () => import("@/views/NotFoundView.vue"),

--- a/frontend/src/services/admin-users.service.ts
+++ b/frontend/src/services/admin-users.service.ts
@@ -1,0 +1,42 @@
+/**
+ * Admin user management service.
+ * Provides operations for managing soft-deleted user accounts (admin only).
+ */
+
+import api from "./api";
+import type {
+  SoftDeletedUserListResponse,
+  PurgeExpiredResponse,
+} from "@/types";
+
+export default {
+  /**
+   * Get a paginated list of soft-deleted users.
+   */
+  async listSoftDeletedUsers(
+    page: number = 1,
+    pageSize: number = 20,
+  ): Promise<SoftDeletedUserListResponse> {
+    const response = await api.get<SoftDeletedUserListResponse>(
+      "/admin/users/soft-deleted",
+      {
+        params: {
+          page,
+          page_size: pageSize,
+        },
+      },
+    );
+    return response.data;
+  },
+
+  /**
+   * Permanently purge all expired soft-deleted user accounts.
+   * This is irreversible.
+   */
+  async purgeExpiredUsers(): Promise<PurgeExpiredResponse> {
+    const response = await api.post<PurgeExpiredResponse>(
+      "/admin/users/purge-expired",
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -10,3 +10,4 @@ export { default as oauthService } from "./oauth.service";
 export { default as adminOAuthService } from "./admin-oauth.service";
 export { default as auditService } from "./audit.service";
 export { default as privacyService } from "./privacy.service";
+export { default as adminUsersService } from "./admin-users.service";

--- a/frontend/src/types/admin-users.types.ts
+++ b/frontend/src/types/admin-users.types.ts
@@ -1,0 +1,33 @@
+/**
+ * Admin user management types matching backend schemas.
+ * @see backend/src/schemas/admin_users.py
+ */
+
+/**
+ * A soft-deleted user account.
+ */
+export interface SoftDeletedUser {
+  user_id: string;
+  email: string;
+  is_email_verified: boolean;
+  is_admin: boolean;
+  deleted_at: string;
+  created_at: string | null;
+}
+
+/**
+ * Paginated list of soft-deleted users.
+ */
+export interface SoftDeletedUserListResponse {
+  users: SoftDeletedUser[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+/**
+ * Response from purging expired soft-deleted accounts.
+ */
+export interface PurgeExpiredResponse {
+  purged_count: number;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,3 +10,4 @@ export * from "./oauth.types";
 export * from "./admin-oauth.types";
 export * from "./audit.types";
 export * from "./privacy.types";
+export * from "./admin-users.types";

--- a/frontend/src/views/admin/AdminSoftDeletedUsersView.vue
+++ b/frontend/src/views/admin/AdminSoftDeletedUsersView.vue
@@ -1,0 +1,403 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { adminUsersService, getErrorMessage } from "@/services";
+import { useUiStore } from "@/stores/ui.store";
+import type { SoftDeletedUser } from "@/types";
+import BaseCard from "@/components/common/BaseCard.vue";
+import BaseButton from "@/components/common/BaseButton.vue";
+import SoftDeletedUserCard from "@/components/admin/SoftDeletedUserCard.vue";
+import { TrashIcon, UsersIcon } from "@heroicons/vue/24/outline";
+
+const uiStore = useUiStore();
+
+const users = ref<SoftDeletedUser[]>([]);
+const isLoading = ref(true);
+const error = ref<string | null>(null);
+const page = ref(1);
+const pageSize = ref(20);
+const total = ref(0);
+
+// Purge modal state
+const showPurgeModal = ref(false);
+const purgeConfirmInput = ref("");
+const isPurging = ref(false);
+
+const canPurge = computed(() => purgeConfirmInput.value === "PURGE");
+
+const expiredCount = computed(() => {
+  const now = new Date();
+  return users.value.filter((u) => {
+    const deletedAt = new Date(u.deleted_at);
+    const purgeDate = new Date(
+      deletedAt.getTime() + 30 * 24 * 60 * 60 * 1000,
+    );
+    return purgeDate <= now;
+  }).length;
+});
+
+async function loadUsers(): Promise<void> {
+  isLoading.value = true;
+  error.value = null;
+
+  try {
+    const response = await adminUsersService.listSoftDeletedUsers(
+      page.value,
+      pageSize.value,
+    );
+    users.value = response.users;
+    total.value = response.total;
+  } catch (err) {
+    error.value = getErrorMessage(err);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+onMounted(loadUsers);
+
+function openPurgeModal(): void {
+  purgeConfirmInput.value = "";
+  showPurgeModal.value = true;
+}
+
+function closePurgeModal(): void {
+  showPurgeModal.value = false;
+  purgeConfirmInput.value = "";
+}
+
+async function confirmPurge(): Promise<void> {
+  if (!canPurge.value) return;
+
+  isPurging.value = true;
+  try {
+    const result = await adminUsersService.purgeExpiredUsers();
+    closePurgeModal();
+    if (result.purged_count > 0) {
+      uiStore.showSuccess(
+        `Permanently purged ${result.purged_count} expired account(s).`,
+      );
+    } else {
+      uiStore.showInfo("No expired accounts to purge.");
+    }
+    await loadUsers();
+  } catch (err) {
+    error.value = getErrorMessage(err);
+  } finally {
+    isPurging.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="admin-soft-deleted-users-view">
+    <div class="container container-lg">
+      <div class="page-header">
+        <div class="header-content">
+          <h1 class="page-title">Soft-Deleted Users</h1>
+          <p class="page-description">
+            User accounts scheduled for permanent deletion. Accounts are
+            automatically purged after a 30-day retention period.
+          </p>
+        </div>
+        <BaseButton
+          v-if="users.length > 0"
+          variant="danger"
+          @click="openPurgeModal"
+        >
+          <TrashIcon class="btn-icon" />
+          Purge Expired
+        </BaseButton>
+      </div>
+
+      <div v-if="!isLoading && users.length > 0" class="summary-bar">
+        <span class="summary-text">
+          {{ total }} soft-deleted account(s), {{ expiredCount }} expired
+        </span>
+      </div>
+
+      <div v-if="isLoading" class="loading-state">
+        <div class="spinner spinner-lg"></div>
+        <p class="loading-text">Loading soft-deleted users...</p>
+      </div>
+
+      <div v-else-if="error" class="alert alert-error">
+        {{ error }}
+      </div>
+
+      <div v-else-if="users.length === 0" class="empty-state">
+        <BaseCard class="empty-card">
+          <div class="empty-icon">
+            <UsersIcon class="icon-lg" />
+          </div>
+          <h3 class="empty-title">No soft-deleted accounts</h3>
+          <p class="empty-description">
+            There are no user accounts currently scheduled for deletion.
+          </p>
+        </BaseCard>
+      </div>
+
+      <div v-else class="users-list">
+        <SoftDeletedUserCard
+          v-for="user in users"
+          :key="user.user_id"
+          :user="user"
+        />
+      </div>
+
+      <div v-if="total > pageSize" class="pagination">
+        <span class="pagination-info">
+          Showing {{ users.length }} of {{ total }} accounts
+        </span>
+      </div>
+    </div>
+
+    <!-- Purge Confirmation Modal -->
+    <div
+      v-if="showPurgeModal"
+      class="modal-overlay"
+      @click.self="closePurgeModal"
+    >
+      <div class="confirm-dialog">
+        <h3 class="confirm-title">Purge Expired Accounts?</h3>
+        <p class="confirm-text">
+          This will permanently delete all soft-deleted accounts whose 30-day
+          retention period has expired. This action is irreversible.
+        </p>
+        <p v-if="expiredCount > 0" class="confirm-count">
+          {{ expiredCount }} account(s) will be permanently purged.
+        </p>
+        <p v-else class="confirm-count confirm-count-none">
+          No accounts have expired yet. Running this will purge 0 accounts.
+        </p>
+        <label class="confirm-label" for="purge-confirm-input">
+          Type PURGE to confirm
+        </label>
+        <input
+          id="purge-confirm-input"
+          v-model="purgeConfirmInput"
+          type="text"
+          class="confirm-input"
+          placeholder="PURGE"
+          autocomplete="off"
+        />
+        <div class="confirm-actions">
+          <BaseButton
+            variant="secondary"
+            :disabled="isPurging"
+            @click="closePurgeModal"
+          >
+            Cancel
+          </BaseButton>
+          <BaseButton
+            variant="danger"
+            :disabled="!canPurge"
+            :loading="isPurging"
+            @click="confirmPurge"
+          >
+            Purge Expired Accounts
+          </BaseButton>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.admin-soft-deleted-users-view {
+  padding: var(--spacing-8) 0;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+  flex-wrap: wrap;
+}
+
+.header-content {
+  flex: 1;
+  min-width: 200px;
+}
+
+.btn-icon {
+  width: 20px;
+  height: 20px;
+  margin-right: var(--spacing-1);
+}
+
+.summary-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+  padding: var(--spacing-3) var(--spacing-4);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.summary-text {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--spacing-12) 0;
+}
+
+.loading-text {
+  margin-top: var(--spacing-4);
+  color: var(--text-tertiary);
+}
+
+.alert-error {
+  padding: var(--spacing-4);
+  background-color: var(--color-error-50);
+  border: 1px solid var(--color-error-200);
+  border-radius: var(--radius-md);
+  color: var(--color-error-700);
+  margin-bottom: var(--spacing-6);
+}
+
+.empty-state {
+  display: flex;
+  justify-content: center;
+}
+
+.empty-card {
+  text-align: center;
+  padding: var(--spacing-12) var(--spacing-8);
+  max-width: 400px;
+}
+
+.empty-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto var(--spacing-4);
+  background-color: var(--bg-tertiary);
+  border-radius: var(--radius-full);
+}
+
+.icon-lg {
+  width: 32px;
+  height: 32px;
+  color: var(--text-tertiary);
+}
+
+.empty-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-2) 0;
+}
+
+.empty-description {
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.users-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-6);
+}
+
+.pagination-info {
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+}
+
+/* Purge Confirmation Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+}
+
+.confirm-dialog {
+  background-color: var(--bg-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  padding: var(--spacing-6);
+  max-width: 440px;
+  width: 90%;
+}
+
+.confirm-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.confirm-text {
+  color: var(--text-secondary);
+  margin: 0 0 var(--spacing-3) 0;
+  line-height: 1.5;
+}
+
+.confirm-count {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-error-600);
+  margin: 0 0 var(--spacing-4) 0;
+}
+
+.confirm-count-none {
+  color: var(--text-tertiary);
+}
+
+.confirm-label {
+  display: block;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-2);
+}
+
+.confirm-input {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background-color: var(--input-bg);
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-4);
+  box-sizing: border-box;
+}
+
+.confirm-input:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 2px var(--color-primary-100);
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+}
+</style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,19 +4,19 @@ import vue from "@vitejs/plugin-vue";
 import vueDevTools from "vite-plugin-vue-devtools";
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueDevTools()],
-  resolve: {
-    alias: {
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    plugins: [vue(), vueDevTools()],
+    resolve: {
+        alias: {
+            "@": fileURLToPath(new URL("./src", import.meta.url)),
+        },
     },
-  },
-  server: {
-    port: 3000,
-    proxy: {
-      "/api": {
-        target: "http://localhost:8000",
-        changeOrigin: true,
-      },
+    server: {
+        port: 3000,
+        proxy: {
+            "/api": {
+                target: "http://localhost:8000",
+                changeOrigin: true,
+            },
+        },
     },
-  },
 });

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,26 +1,24 @@
 import { fileURLToPath } from "node:url";
 import { mergeConfig, defineConfig, configDefaults } from "vitest/config";
 import viteConfig from "./vite.config";
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
+export default mergeConfig(viteConfig, defineConfig({
     test: {
-      environment: "happy-dom",
-      exclude: [...configDefaults.exclude, "e2e/**"],
-      root: fileURLToPath(new URL("./", import.meta.url)),
-      setupFiles: ["./src/tests/setup.ts"],
-      coverage: {
-        provider: "v8",
-        reporter: ["text", "json", "html"],
-        exclude: [
-          "node_modules/",
-          "src/tests/",
-          "**/*.d.ts",
-          "**/*.config.*",
-          "**/types/**",
-        ],
-      },
-      globals: true,
+        environment: "happy-dom",
+        exclude: [...configDefaults.exclude, "e2e/**"],
+        root: fileURLToPath(new URL("./", import.meta.url)),
+        setupFiles: ["./src/tests/setup.ts"],
+        coverage: {
+            provider: "v8",
+            include: ["src/**"],
+            reporter: ["text", "json", "html"],
+            exclude: [
+                "node_modules/",
+                "src/tests/",
+                "**/*.d.ts",
+                "**/*.config.*",
+                "**/types/**",
+            ],
+        },
+        globals: true,
     },
-  }),
-);
+}));


### PR DESCRIPTION
## Summary

Admin endpoint to list all soft-deleted accounts
Admin endpoint to trigge purge of expired accounts
Vue admin page at `/admin/users/soft-deleted` 
13 new tests (5 unit, 8 integration), all 596 backend tests pass

## Test plan

- [x] Login as admin, navigate to Admin > Deleted Users
- [x] Verify empty state when no soft-deleted accounts exist
- [x] Soft-delete a user via Settings, verify it appears in the admin list with correct badges and days remaining
- [x] Click "Purge Expired", type PURGE, confirm (expect 0 purged if no accounts past 30-day retention)
- [x] Verify mobile navigation link works
- [x] Run `docker compose exec api pytest` (596 tests pass)
- [x] Run `npm run build` in frontend (zero errors)