### PR TITLE
Add automatic context deactivation on document expiry

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -51,13 +51,13 @@ services:
       timeout: 3s
       retries: 5
 
-  # Celery worker for async email tasks
+  # Celery worker for async email and maintenance tasks
   celery_worker:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: identity-celery-worker
-    command: celery -A src.core.celery_app worker --loglevel=info -Q emails
+    command: celery -A src.core.celery_app worker --loglevel=info -Q emails,maintenance
     volumes:
       - ./src:/app/src
     env_file:
@@ -67,9 +67,35 @@ services:
       - PYTHONPATH=/app
       # Redis connection
       - REDIS_URL=redis://redis:6379/0
+      # Database connection (required by maintenance tasks)
+      - DATABASE_URL=postgresql://postgres:postgres@host.docker.internal:54322/postgres
       # SMTP for Mailpit on host
       - SMTP_HOST=host.docker.internal
       - SMTP_PORT=54325
+      # JWT secret (required by config)
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-local-jwt-secret-for-celery-worker}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  # Celery Beat scheduler for periodic tasks
+  celery_beat:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: identity-celery-beat
+    command: celery -A src.core.celery_app beat --loglevel=info
+    volumes:
+      - ./src:/app/src
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      # Redis connection
+      - REDIS_URL=redis://redis:6379/0
       # JWT secret (required by config)
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-local-jwt-secret-for-celery-worker}
     extra_hosts:

--- a/backend/src/core/celery_app.py
+++ b/backend/src/core/celery_app.py
@@ -1,11 +1,20 @@
 """
 Celery Application Configuration
 
-Configures Celery for async task processing, primarily for email sending.
-Uses Redis as message broker and result backend.
+Configures Celery for async task processing (email sending, periodic
+maintenance tasks). Uses Redis as message broker and result backend.
+
+Queues:
+    emails - outbound email delivery (verification, reset, etc.)
+    maintenance - periodic background jobs (document expiry checks)
+
+Beat schedule:
+    check_expired_documents - runs every 8 hours
 """
 
 from celery import Celery
+from celery.schedules import crontab
+
 from src.core.config import settings
 
 
@@ -28,13 +37,24 @@ celery_app.conf.update(
         "send_password_reset_email": {"queue": "emails"},
         "send_restoration_email": {"queue": "emails"},
         "send_rejection_email": {"queue": "emails"},
-        "send_approval_email": {"queue": "emails"}
+        "send_approval_email": {"queue": "emails"},
+        "send_document_expiry_email": {"queue": "emails"},
+        "check_expired_documents": {"queue": "maintenance"},
     },
     task_track_started=True,
     task_time_limit=30 * 60,  # 30 minutes max per task
     task_soft_time_limit=25 * 60,  # 25 minutes soft limit
     worker_prefetch_multiplier=1,  # One task at a time for email queue
     worker_max_tasks_per_child=1000,  # Restart worker after 1000 tasks
-    imports=["src.tasks.email_tasks"]  # Explicitly import task modules
+    imports=[
+        "src.tasks.email_tasks",
+        "src.tasks.expiry_tasks",
+    ],
+    beat_schedule={
+        "check-expired-documents-daily": {
+            "task": "check_expired_documents",
+            "schedule": crontab(minute=0, hour="*/8"),  # Every 8 hours
+        },
+    },
 )
 

--- a/backend/src/core/storage.py
+++ b/backend/src/core/storage.py
@@ -66,12 +66,14 @@ class SupabaseStorageClient:
         self._client = create_client(supabase_url, supabase_key)
         self._supabase_url = supabase_url.rstrip("/")
         self._public_url = public_url.rstrip("/") if public_url else ""
+        self._bucket_confirmed = False
         self._ensure_bucket()
 
     def _ensure_bucket(self) -> None:
         """Create the avatars bucket if it does not already exist."""
         try:
             self._client.storage.get_bucket(self.BUCKET)
+            self._bucket_confirmed = True
             logger.info("Storage bucket '%s' exists", self.BUCKET)
         except Exception:
             try:
@@ -79,16 +81,19 @@ class SupabaseStorageClient:
                     self.BUCKET,
                     options={"public": True},
                 )
+                self._bucket_confirmed = True
                 logger.info("Created storage bucket '%s'", self.BUCKET)
             except Exception as exc:
                 logger.warning(
                     "Could not create bucket '%s': %s. "
-                    "Uploads will fail until the bucket is created manually.",
+                    "Will retry on first upload.",
                     self.BUCKET, exc,
                 )
 
     def upload(self, path: str, data: bytes, content_type: str) -> StorageUploadResult:
         """Upload to Supabase Storage, overwriting any existing object at the path."""
+        if not self._bucket_confirmed:
+            self._ensure_bucket()
         self._client.storage.from_(self.BUCKET).upload(
             path,
             data,
@@ -147,12 +152,14 @@ class SupabaseDocumentStorageClient:
         self._client = create_client(supabase_url, supabase_key)
         self._supabase_url = supabase_url.rstrip("/")
         self._public_url = public_url.rstrip("/") if public_url else ""
+        self._bucket_confirmed = False
         self._ensure_bucket()
 
     def _ensure_bucket(self) -> None:
         """Create the private bucket if it does not already exist."""
         try:
             self._client.storage.get_bucket(self.BUCKET)
+            self._bucket_confirmed = True
             logger.info("Storage bucket '%s' exists", self.BUCKET)
         except Exception:
             try:
@@ -160,16 +167,19 @@ class SupabaseDocumentStorageClient:
                     self.BUCKET,
                     options={"public": False},
                 )
+                self._bucket_confirmed = True
                 logger.info("Created private storage bucket '%s'", self.BUCKET)
             except Exception as exc:
                 logger.warning(
                     "Could not create bucket '%s': %s. "
-                    "Uploads will fail until the bucket is created manually.",
+                    "Will retry on first upload.",
                     self.BUCKET, exc,
                 )
 
     def upload(self, path: str, data: bytes, content_type: str) -> StorageUploadResult:
         """Upload encrypted bytes to the private bucket."""
+        if not self._bucket_confirmed:
+            self._ensure_bucket()
         self._client.storage.from_(self.BUCKET).upload(
             path,
             data,

--- a/backend/src/models/audit.py
+++ b/backend/src/models/audit.py
@@ -87,6 +87,7 @@ class AuditEventType(str, enum.Enum):
     document_review = "verification.document.review"
     document_delete = "verification.document.delete"
     document_view = "verification.document.view"
+    document_expiry = "verification.document.expiry"
 
 
 # SHA-256 of b"GENESIS" - used as previous_hash for the first entry in the chain

--- a/backend/src/models/verification.py
+++ b/backend/src/models/verification.py
@@ -40,6 +40,7 @@ class VerificationStatus(str, enum.Enum):
     under_review = "under_review"
     verified = "verified"
     rejected = "rejected"
+    expired = "expired"
 
 
 class VerificationDocument(Base, TimestampMixin, SoftDeleteMixin):

--- a/backend/src/repositories/context_repository.py
+++ b/backend/src/repositories/context_repository.py
@@ -319,6 +319,33 @@ class ContextRepository:
             .all()
         )
 
+    def get_active_contexts_by_document_id(
+        self, document_id: UUID
+    ) -> List[ContextProfile]:
+        """
+        Return all active, non-deleted contexts linked to the given document.
+
+        Used by the expiry task to find contexts that need deactivation
+        when their backing verification document expires.
+
+        Args:
+            document_id: Verification document ID
+
+        Returns:
+            List of active context profiles linked to the document
+        """
+        return (
+            self.db.query(ContextProfile)
+            .filter(
+                and_(
+                    ContextProfile.document_id == str(document_id),
+                    ContextProfile.is_active == True,
+                    ContextProfile.deleted_at.is_(None),
+                )
+            )
+            .all()
+        )
+
     def restore_user_contexts(self, user_id: UUID) -> int:
         """
         Restore all soft-deleted context profiles for a user.

--- a/backend/src/repositories/verification_repository.py
+++ b/backend/src/repositories/verification_repository.py
@@ -110,6 +110,54 @@ class VerificationRepository:
             .first()
         )
 
+    def get_expired_verified_documents(self) -> List[VerificationDocument]:
+        """
+        Return all non-deleted, verified documents whose physical expiry
+        date has passed.
+
+        Only returns documents that:
+        - Have ``verification_status = 'verified'``
+        - Have a non-null ``document_expiry_date``
+        - Have ``document_expiry_date < date.today()``
+        - Are not soft-deleted
+
+        Used by the daily expiry task to find documents that need processing.
+        """
+        today = date.today()
+        return (
+            self.db.query(VerificationDocument)
+            .filter(
+                and_(
+                    VerificationDocument.verification_status
+                    == VerificationStatus.verified,
+                    VerificationDocument.document_expiry_date.isnot(None),
+                    VerificationDocument.document_expiry_date < today,
+                    VerificationDocument.deleted_at.is_(None),
+                )
+            )
+            .all()
+        )
+
+    def mark_document_expired(
+        self, document_id: UUID
+    ) -> Optional[VerificationDocument]:
+        """
+        Transition a document to the ``expired`` status.
+
+        Called after the expiry task has deactivated all linked contexts.
+        Prevents re-processing on subsequent runs since the daily query
+        filters on ``verification_status = 'verified'``.
+        """
+        doc = self.get_document_by_id(document_id)
+        if doc is None:
+            return None
+
+        doc.verification_status = VerificationStatus.expired
+        doc.updated_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(doc)
+        return doc
+
     def get_documents_by_status(
         self,
         statuses: List[VerificationStatus],

--- a/backend/src/services/verification_service.py
+++ b/backend/src/services/verification_service.py
@@ -77,8 +77,8 @@ class VerificationService:
         self,
         verification_repo: VerificationRepository,
         profile_repo: ProfileRepository,
-        storage: StorageClient,
-        encryption: EncryptionService,
+        storage: Optional[StorageClient] = None,
+        encryption: Optional[EncryptionService] = None,
         audit_service: Optional[AuditService] = None,
         context_repo: Optional[ContextRepository] = None,
     ) -> None:
@@ -851,3 +851,134 @@ class VerificationService:
                 )
 
         return result
+
+    # ------------------------------------------------------------------
+    # Automatic document expiry
+    # ------------------------------------------------------------------
+
+    def process_expired_documents(self) -> Dict:
+        """
+        Find all verified documents past their expiry date, deactivate
+        linked contexts, mark documents as expired, send notifications,
+        and log audit events.
+
+        For each expired document the method:
+        1. Deactivates all active contexts linked to the document
+           (``is_active=False``, ``verification_status=pending``)
+        2. Unlinks the document from each affected context
+        3. Logs an audit event per deactivated context
+        4. Marks the document as ``expired`` to prevent re-processing
+        5. Sends a single notification email per user listing the
+           affected context names
+
+        Returns:
+            Dict with ``expired_documents`` and ``deactivated_contexts``
+            counts.
+
+        Raises:
+            VerificationServiceError: If context_repo is not configured.
+        """
+        if self.context_repo is None:
+            raise VerificationServiceError(
+                "Context repository not configured", status_code=500
+            )
+
+        expired_docs = (
+            self.verification_repo.get_expired_verified_documents()
+        )
+        deactivated_count = 0
+
+        for doc in expired_docs:
+            contexts = self.context_repo.get_active_contexts_by_document_id(
+                doc.id
+            )
+
+            for ctx in contexts:
+                # Deactivate the context and reset to pending verification
+                self.context_repo.update_verification_status(
+                    context_id=ctx.id,
+                    verification_status=VerificationStatus.pending,
+                    is_active=False,
+                )
+
+                # Unlink the expired document
+                self.verification_repo.unlink_document_from_context(
+                    ctx.id, doc.id
+                )
+                deactivated_count += 1
+
+                # Audit each deactivated context
+                if self.audit_service:
+                    try:
+                        self.audit_service.log_event(
+                            event_type=AuditEventType.document_expiry,
+                            user_id=ctx.user_id,
+                            actor_id=None,
+                            resource_type="context_profile",
+                            resource_id=str(ctx.id),
+                            operation=AuditOperation.update,
+                            changes={
+                                "reason": "document_expired",
+                                "document_id": str(doc.id),
+                                "document_expiry_date": str(
+                                    doc.document_expiry_date
+                                ),
+                                "previous_verification_status": (
+                                    ctx.verification_status.value
+                                    if ctx.verification_status
+                                    else None
+                                ),
+                            },
+                            legal_basis="legitimate_interest",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Audit logging failed for document expiry "
+                            "context %s",
+                            ctx.id,
+                            exc_info=True,
+                        )
+
+                logger.info(
+                    "Context %s deactivated: document %s expired on %s",
+                    ctx.id, doc.id, doc.document_expiry_date,
+                )
+
+            # Mark the document as expired to prevent re-processing
+            self.verification_repo.mark_document_expired(doc.id)
+
+            # Send one notification email per user
+            context_names = [
+                c.context_name or c.context_type.value for c in contexts
+            ]
+            if context_names:
+                profile = self.profile_repo.get_profile_by_id(doc.user_id)
+                if profile and profile.primary_email:
+                    try:
+                        from src.tasks.email_tasks import (
+                            send_document_expiry_email,
+                        )
+
+                        send_document_expiry_email.delay(
+                            profile.primary_email,
+                            profile.legal_name or profile.primary_email,
+                            context_names,
+                            str(doc.document_expiry_date),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to queue expiry email for document %s",
+                            doc.id,
+                            exc_info=True,
+                        )
+
+        logger.info(
+            "Document expiry check complete: %d documents, %d contexts "
+            "deactivated",
+            len(expired_docs), deactivated_count,
+        )
+
+        return {
+            "expired_documents": len(expired_docs),
+            "deactivated_contexts": deactivated_count,
+        }

--- a/backend/src/tasks/email_tasks.py
+++ b/backend/src/tasks/email_tasks.py
@@ -534,3 +534,100 @@ def send_approval_email(self, email: str, user_name: str, context_name: str):
 
     except Exception as exc:
         raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+
+
+@celery_app.task(name="send_document_expiry_email", bind=True, max_retries=3)
+def send_document_expiry_email(
+    self,
+    email: str,
+    user_name: str,
+    context_names: list,
+    expiry_date: str,
+):
+    """
+    Send document expiry notification via SMTP.
+
+    Informs the user that their verification document has expired
+    and lists the context profiles that were deactivated as a result.
+    Retries up to 3 times on failure with exponential backoff.
+
+    Args:
+        email: Recipient email address
+        user_name: Display name of the user
+        context_names: Names of the deactivated contexts
+        expiry_date: Document expiry date as ISO string
+    """
+    try:
+        documents_url = f"{settings.FRONTEND_URL}/documents"
+        contexts_list = ", ".join(context_names)
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = "Verification document expired"
+        msg["From"] = settings.SMTP_FROM_EMAIL
+        msg["To"] = email
+
+        text = f"""
+        Verification Document Expired
+
+        Hello {user_name},
+
+        Your verification document expired on {expiry_date}.
+
+        The following context profiles have been deactivated:
+        {contexts_list}
+
+        To reactivate these contexts, upload a new valid document at:
+        {documents_url}
+
+        Best regards,
+        Identity Management Team
+        """
+
+        contexts_html_items = "".join(
+            f"<li>{name}</li>" for name in context_names
+        )
+        html = f"""
+        <html>
+          <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+            <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+              <h2 style="color: #d97706;">Verification Document Expired</h2>
+              <p>Hello {user_name},</p>
+              <p>Your verification document expired on
+                 <strong>{expiry_date}</strong>.</p>
+              <div style="background-color: #fffbeb; border-left: 4px solid #d97706;
+                          padding: 12px 16px; margin: 20px 0; border-radius: 4px;">
+                <p style="margin: 0 0 8px 0; color: #92400e;">
+                  <strong>Deactivated contexts:</strong>
+                </p>
+                <ul style="margin: 0; padding-left: 20px; color: #92400e;">
+                  {contexts_html_items}
+                </ul>
+              </div>
+              <p>To reactivate these contexts, upload a new valid document:</p>
+              <div style="text-align: center; margin: 30px 0;">
+                <a href="{documents_url}"
+                   style="background-color: #d97706; color: white; padding: 12px 30px;
+                          text-decoration: none; border-radius: 5px;
+                          display: inline-block;">
+                  Upload New Document
+                </a>
+              </div>
+              <hr style="border: none; border-top: 1px solid #ddd; margin: 20px 0;">
+              <p style="color: #999; font-size: 12px;">
+                This is an automated notification from the Identity Management System.
+              </p>
+            </div>
+          </body>
+        </html>
+        """
+
+        msg.attach(MIMEText(text, "plain"))
+        msg.attach(MIMEText(html, "html"))
+
+        with get_smtp_connection() as server:
+            server.send_message(msg)
+
+        return {"status": "sent", "email": email}
+
+    except Exception as exc:
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)

--- a/backend/src/tasks/expiry_tasks.py
+++ b/backend/src/tasks/expiry_tasks.py
@@ -1,0 +1,59 @@
+"""
+Document Expiry Tasks
+
+Celery periodic task that checks for expired verification documents
+and deactivates their linked context profiles. Runs daily via Celery
+Beat at 02:00 UTC.
+
+The business logic lives in VerificationService.process_expired_documents().
+This module provides only the Celery task wrapper that manages the
+database session lifecycle and retry semantics.
+"""
+
+import logging
+
+from src.core.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="check_expired_documents", bind=True, max_retries=3)
+def check_expired_documents(self):
+    """
+    Daily periodic task: find verified documents past their expiry
+    date, deactivate linked contexts, and send notifications.
+
+    Creates its own database session because Celery workers run
+    outside the FastAPI request lifecycle.
+
+    Returns:
+        Dict with expired_documents and deactivated_contexts counts.
+    """
+    from src.core.database import SessionLocal
+    from src.repositories.context_repository import ContextRepository
+    from src.repositories.profile_repository import ProfileRepository
+    from src.repositories.verification_repository import (
+        VerificationRepository,
+    )
+    from src.services.audit_service import AuditService
+    from src.repositories.audit_repository import AuditRepository
+    from src.services.verification_service import VerificationService
+
+    db = SessionLocal()
+    try:
+        service = VerificationService(
+            verification_repo=VerificationRepository(db),
+            profile_repo=ProfileRepository(db),
+            audit_service=AuditService(AuditRepository(db)),
+            context_repo=ContextRepository(db),
+        )
+        result = service.process_expired_documents()
+        logger.info("check_expired_documents completed: %s", result)
+        return result
+    except Exception as exc:
+        logger.error(
+            "check_expired_documents failed: %s", exc, exc_info=True
+        )
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+    finally:
+        db.close()

--- a/backend/supabase/migrations/20260223000000_add_expired_verification_status.sql
+++ b/backend/supabase/migrations/20260223000000_add_expired_verification_status.sql
@@ -1,0 +1,4 @@
+-- Add 'expired' value to the verification_status enum.
+-- Used by the daily Celery Beat task to mark documents whose
+-- document_expiry_date has passed, preventing re-processing.
+ALTER TYPE verification_status ADD VALUE 'expired';

--- a/backend/tests/unit/test_expiry_tasks.py
+++ b/backend/tests/unit/test_expiry_tasks.py
@@ -1,0 +1,478 @@
+"""
+Document Expiry Task Unit Tests
+
+Tests business logic for automatic context deactivation when linked
+verification documents expire. Covers the
+``VerificationService.process_expired_documents`` method using
+mocked repositories and email tasks.
+"""
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.models.context import ContextProfile, ContextType
+from src.models.profile import AccountType, BaseProfile
+from src.models.verification import (
+    DocumentType,
+    VerificationDocument,
+    VerificationStatus,
+)
+from src.services.verification_service import (
+    VerificationService,
+    VerificationServiceError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_expired_document(
+    doc_id=None,
+    user_id=None,
+    expiry_date=None,
+) -> MagicMock:
+    """Create a mock verified document with an expiry date in the past."""
+    doc = MagicMock(spec=VerificationDocument)
+    doc.id = str(doc_id or uuid.uuid4())
+    doc.user_id = str(user_id or uuid.uuid4())
+    doc.document_type = DocumentType.passport
+    doc.verification_status = VerificationStatus.verified
+    doc.document_expiry_date = expiry_date or (
+        date.today() - timedelta(days=1)
+    )
+    doc.storage_path = f"{doc.user_id}/blob/doc.pdf"
+    doc.original_filename = "passport.pdf"
+    doc.file_size_bytes = 2048
+    doc.content_type = "application/pdf"
+    doc.created_at = datetime.now(timezone.utc)
+    doc.updated_at = datetime.now(timezone.utc)
+    return doc
+
+
+def _make_active_context(
+    context_id=None,
+    user_id=None,
+    context_type=ContextType.legal,
+    context_name="Government ID",
+) -> MagicMock:
+    """Create a mock active context profile linked to a document."""
+    ctx = MagicMock(spec=ContextProfile)
+    ctx.id = str(context_id or uuid.uuid4())
+    ctx.user_id = user_id or str(uuid.uuid4())
+    ctx.context_type = context_type
+    ctx.context_name = context_name
+    ctx.verification_status = VerificationStatus.verified
+    ctx.is_active = True
+    ctx.rejection_reason = None
+    return ctx
+
+
+def _make_profile(
+    user_id=None,
+    account_type=AccountType.verified,
+) -> MagicMock:
+    """Create a mock base profile."""
+    profile = MagicMock(spec=BaseProfile)
+    profile.user_id = str(user_id or uuid.uuid4())
+    profile.account_type = account_type
+    profile.legal_name = "Test User"
+    profile.primary_email = "test@example.com"
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_verification_repo():
+    repo = MagicMock()
+    repo.get_expired_verified_documents.return_value = []
+    repo.mark_document_expired.return_value = None
+    repo.unlink_document_from_context.return_value = True
+    return repo
+
+
+@pytest.fixture
+def mock_context_repo():
+    repo = MagicMock()
+    repo.get_active_contexts_by_document_id.return_value = []
+    return repo
+
+
+@pytest.fixture
+def mock_profile_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_audit_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def service(
+    mock_verification_repo,
+    mock_profile_repo,
+    mock_context_repo,
+    mock_audit_service,
+):
+    """Service instance configured for expiry processing (no storage/encryption)."""
+    return VerificationService(
+        verification_repo=mock_verification_repo,
+        profile_repo=mock_profile_repo,
+        audit_service=mock_audit_service,
+        context_repo=mock_context_repo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessExpiredDocuments:
+    """Tests for VerificationService.process_expired_documents."""
+
+    def test_no_expired_documents(self, service, mock_verification_repo):
+        """Returns zero counts when no documents have expired."""
+        mock_verification_repo.get_expired_verified_documents.return_value = []
+
+        result = service.process_expired_documents()
+
+        assert result == {"expired_documents": 0, "deactivated_contexts": 0}
+        mock_verification_repo.mark_document_expired.assert_not_called()
+
+    def test_deactivates_context_for_expired_document(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """An expired verified document deactivates its linked active context."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        ctx = _make_active_context(user_id=user_id)
+        profile = _make_profile(user_id=user_id)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = [ctx]
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        with patch("src.tasks.email_tasks.send_document_expiry_email"):
+            result = service.process_expired_documents()
+
+        assert result == {"expired_documents": 1, "deactivated_contexts": 1}
+
+        mock_context_repo.update_verification_status.assert_called_once_with(
+            context_id=ctx.id,
+            verification_status=VerificationStatus.pending,
+            is_active=False,
+        )
+        mock_verification_repo.unlink_document_from_context.assert_called_once_with(
+            ctx.id, doc.id
+        )
+
+    def test_marks_document_as_expired_after_processing(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+    ):
+        """The document's status transitions to 'expired' after processing."""
+        doc = _make_expired_document()
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = []
+
+        result = service.process_expired_documents()
+
+        mock_verification_repo.mark_document_expired.assert_called_once_with(
+            doc.id
+        )
+        assert result["expired_documents"] == 1
+
+    def test_unlinks_document_from_each_context(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """All linked contexts are unlinked from the expired document."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        ctx1 = _make_active_context(user_id=user_id, context_name="Legal")
+        ctx2 = _make_active_context(
+            user_id=user_id,
+            context_type=ContextType.healthcare,
+            context_name="Healthcare",
+        )
+        profile = _make_profile(user_id=user_id)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = [
+            ctx1, ctx2
+        ]
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        with patch("src.tasks.email_tasks.send_document_expiry_email"):
+            result = service.process_expired_documents()
+
+        assert result["deactivated_contexts"] == 2
+        assert mock_verification_repo.unlink_document_from_context.call_count == 2
+
+    @patch("src.tasks.email_tasks.send_document_expiry_email")
+    def test_sends_notification_email(
+        self,
+        mock_email_task,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """A notification email is queued for each affected user."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        ctx = _make_active_context(user_id=user_id, context_name="Legal ID")
+        profile = _make_profile(user_id=user_id)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = [ctx]
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        service.process_expired_documents()
+
+        mock_email_task.delay.assert_called_once_with(
+            profile.primary_email,
+            profile.legal_name,
+            ["Legal ID"],
+            str(doc.document_expiry_date),
+        )
+
+    def test_no_email_when_no_contexts_affected(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """No email is sent when an expired document has no active contexts."""
+        doc = _make_expired_document()
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = []
+
+        service.process_expired_documents()
+
+        mock_profile_repo.get_profile_by_id.assert_not_called()
+
+    def test_email_failure_does_not_block_processing(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """If email queuing fails, remaining documents are still processed."""
+        user_id_1 = str(uuid.uuid4())
+        user_id_2 = str(uuid.uuid4())
+        doc1 = _make_expired_document(user_id=user_id_1)
+        doc2 = _make_expired_document(user_id=user_id_2)
+        ctx1 = _make_active_context(user_id=user_id_1)
+        ctx2 = _make_active_context(user_id=user_id_2)
+        profile1 = _make_profile(user_id=user_id_1)
+        profile2 = _make_profile(user_id=user_id_2)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [
+            doc1, doc2
+        ]
+        mock_context_repo.get_active_contexts_by_document_id.side_effect = [
+            [ctx1], [ctx2]
+        ]
+        mock_profile_repo.get_profile_by_id.side_effect = [profile1, profile2]
+
+        with patch(
+            "src.tasks.email_tasks.send_document_expiry_email",
+        ) as mock_email:
+            mock_email.delay.side_effect = [Exception("Redis down"), None]
+            result = service.process_expired_documents()
+
+        # Both documents should be processed despite email failure
+        assert result == {"expired_documents": 2, "deactivated_contexts": 2}
+        assert mock_verification_repo.mark_document_expired.call_count == 2
+
+    def test_logs_audit_event_per_context(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_audit_service,
+        mock_profile_repo,
+    ):
+        """An audit event is recorded for each deactivated context."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        ctx1 = _make_active_context(user_id=user_id)
+        ctx2 = _make_active_context(user_id=user_id)
+        profile = _make_profile(user_id=user_id)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = [
+            ctx1, ctx2
+        ]
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        with patch("src.tasks.email_tasks.send_document_expiry_email"):
+            service.process_expired_documents()
+
+        assert mock_audit_service.log_event.call_count == 2
+
+    def test_processes_multiple_expired_documents(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """Multiple expired documents are all processed in a single run."""
+        docs = [_make_expired_document() for _ in range(3)]
+        contexts = [
+            [_make_active_context(user_id=d.user_id)] for d in docs
+        ]
+
+        mock_verification_repo.get_expired_verified_documents.return_value = docs
+        mock_context_repo.get_active_contexts_by_document_id.side_effect = contexts
+        mock_profile_repo.get_profile_by_id.side_effect = [
+            _make_profile(user_id=d.user_id) for d in docs
+        ]
+
+        with patch("src.tasks.email_tasks.send_document_expiry_email"):
+            result = service.process_expired_documents()
+
+        assert result == {"expired_documents": 3, "deactivated_contexts": 3}
+        assert mock_verification_repo.mark_document_expired.call_count == 3
+
+    def test_returns_correct_counts(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """Counts reflect total documents and total contexts deactivated."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        contexts = [
+            _make_active_context(user_id=user_id) for _ in range(3)
+        ]
+        profile = _make_profile(user_id=user_id)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = contexts
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        with patch("src.tasks.email_tasks.send_document_expiry_email"):
+            result = service.process_expired_documents()
+
+        assert result["expired_documents"] == 1
+        assert result["deactivated_contexts"] == 3
+
+    def test_raises_without_context_repo(
+        self,
+        mock_verification_repo,
+        mock_profile_repo,
+        mock_audit_service,
+    ):
+        """Raises VerificationServiceError if context_repo is not configured."""
+        svc = VerificationService(
+            verification_repo=mock_verification_repo,
+            profile_repo=mock_profile_repo,
+            audit_service=mock_audit_service,
+            context_repo=None,
+        )
+
+        with pytest.raises(VerificationServiceError) as exc_info:
+            svc.process_expired_documents()
+
+        assert exc_info.value.status_code == 500
+        assert "Context repository not configured" in str(exc_info.value)
+
+    def test_service_without_storage_encryption(
+        self,
+        mock_verification_repo,
+        mock_profile_repo,
+        mock_context_repo,
+        mock_audit_service,
+    ):
+        """Service can be instantiated without storage/encryption for expiry tasks."""
+        svc = VerificationService(
+            verification_repo=mock_verification_repo,
+            profile_repo=mock_profile_repo,
+            audit_service=mock_audit_service,
+            context_repo=mock_context_repo,
+        )
+
+        assert svc.storage is None
+        assert svc.encryption is None
+
+        mock_verification_repo.get_expired_verified_documents.return_value = []
+        result = svc.process_expired_documents()
+        assert result == {"expired_documents": 0, "deactivated_contexts": 0}
+
+    def test_no_email_when_user_has_no_email(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """No email is sent when the user's profile has no primary_email."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        ctx = _make_active_context(user_id=user_id)
+        profile = _make_profile(user_id=user_id)
+        profile.primary_email = None
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = [ctx]
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        # Should not raise and should not attempt to send email
+        with patch(
+            "src.tasks.email_tasks.send_document_expiry_email",
+        ) as mock_email:
+            service.process_expired_documents()
+            mock_email.delay.assert_not_called()
+
+    def test_context_name_fallback_to_type(
+        self,
+        service,
+        mock_verification_repo,
+        mock_context_repo,
+        mock_profile_repo,
+    ):
+        """When context_name is None, context_type.value is used in email."""
+        user_id = str(uuid.uuid4())
+        doc = _make_expired_document(user_id=user_id)
+        ctx = _make_active_context(user_id=user_id)
+        ctx.context_name = None
+        ctx.context_type = ContextType.legal
+        profile = _make_profile(user_id=user_id)
+
+        mock_verification_repo.get_expired_verified_documents.return_value = [doc]
+        mock_context_repo.get_active_contexts_by_document_id.return_value = [ctx]
+        mock_profile_repo.get_profile_by_id.return_value = profile
+
+        with patch(
+            "src.tasks.email_tasks.send_document_expiry_email",
+        ) as mock_email:
+            service.process_expired_documents()
+            call_args = mock_email.delay.call_args
+            context_names_arg = call_args[0][2]
+            assert context_names_arg == ["legal"]

--- a/frontend/src/views/VerificationView.vue
+++ b/frontend/src/views/VerificationView.vue
@@ -69,7 +69,7 @@ onMounted(loadData);
 
 <template>
   <div class="documents-view">
-    <div class="container container-md">
+    <div class="container container-lg">
       <div class="page-header">
         <h1 class="page-title">
           {{ t("documents.title") }}


### PR DESCRIPTION
## Summary
Celery Beat periodic task (every 8 hours) scans for verified documents past their expiry date, deactivates linked context profiles & sends notification email

## Test plan
- [x] 14 unit tests for `process_expired_documents()`
- [x] Manual test: insert expired document in DB, trigger task, verify context deactivation
- [x] Verify notification email in Mailpit
- [x] Verify audit log entry created