### PR TITLE
Disambiguate verification pending badges

### DIFF
--- a/backend/src/models/context.py
+++ b/backend/src/models/context.py
@@ -88,6 +88,11 @@ class ContextProfile(Base, TimestampMixin, SoftDeleteMixin, TemporalMixin):
         """Return True if this context has been identity-verified by an admin."""
         return self.verification_status == VerificationStatus.verified
 
+    @property
+    def has_linked_document(self) -> bool:
+        """Return True if a verification document is linked to this context."""
+        return self.document_id is not None
+
     def has_overrides(self) -> bool:
         """Check if this context has any field overrides"""
         return any(

--- a/backend/src/schemas/context.py
+++ b/backend/src/schemas/context.py
@@ -121,6 +121,7 @@ class ContextProfileResponse(BaseModel):
     avatar_override_thumbnail_url: str | None = None
     is_active: bool
     verification_status: str | None = None
+    has_linked_document: bool = False
     rejection_reason: str | None = None
     created_at: datetime
     updated_at: datetime

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -223,6 +223,8 @@
     "pseudonymousRestriction": "Note: Pseudonymous accounts cannot create legal or healthcare contexts.",
     "verificationNotice": "This context requires identity verification. After creation, it will remain inactive until you upload a verification document and an administrator approves it.",
     "verificationPending": "Verification pending",
+    "verificationDocumentRequired": "Document required",
+    "verificationAwaitingReview": "Awaiting review",
     "verificationVerified": "Verified",
     "verificationRejected": "Verification rejected",
     "verificationExpired": "Document expired",
@@ -543,7 +545,8 @@
       "pending": "Pending",
       "under_review": "Under Review",
       "verified": "Verified",
-      "rejected": "Rejected"
+      "rejected": "Rejected",
+      "expired": "Expired"
     },
     "documentTypes": {
       "passport": "Passport",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -207,6 +207,8 @@
     "pseudonymousRestriction": "Nota: gli account pseudonimi non possono creare contesti legali o sanitari.",
     "verificationNotice": "Questo contesto richiede la verifica dell'identita. Dopo la creazione, rimarra inattivo fino a quando non caricherai un documento di verifica e un amministratore lo approvera.",
     "verificationPending": "Verifica in attesa",
+    "verificationDocumentRequired": "Documento richiesto",
+    "verificationAwaitingReview": "In attesa di revisione",
     "verificationVerified": "Verificato",
     "verificationRejected": "Verifica rifiutata",
     "verificationExpired": "Documento scaduto",
@@ -497,7 +499,8 @@
       "pending": "In attesa",
       "under_review": "In revisione",
       "verified": "Verificato",
-      "rejected": "Rifiutato"
+      "rejected": "Rifiutato",
+      "expired": "Scaduto"
     },
     "documentTypes": {
       "passport": "Passaporto",

--- a/frontend/src/types/context.types.ts
+++ b/frontend/src/types/context.types.ts
@@ -55,6 +55,7 @@ export interface ContextProfileResponse {
   avatar_override_thumbnail_url: string | null;
   is_active: boolean;
   verification_status: string | null;
+  has_linked_document: boolean;
   rejection_reason: string | null;
   created_at: string;
   updated_at: string;

--- a/frontend/src/views/ContextDetailView.vue
+++ b/frontend/src/views/ContextDetailView.vue
@@ -469,11 +469,18 @@ function formatFileSize(bytes: number): string {
                       {{ CONTEXT_TYPE_META[context.context_type]?.label }}
                     </BaseBadge>
                     <BaseBadge
-                      v-if="context.verification_status === 'pending'"
+                      v-if="context.verification_status === 'pending' && !context.has_linked_document"
                       variant="warning"
                       size="sm"
                     >
-                      {{ t("context.verificationPending") }}
+                      {{ t("context.verificationDocumentRequired") }}
+                    </BaseBadge>
+                    <BaseBadge
+                      v-else-if="context.verification_status === 'pending' && context.has_linked_document"
+                      variant="info"
+                      size="sm"
+                    >
+                      {{ t("context.verificationAwaitingReview") }}
                     </BaseBadge>
                     <BaseBadge
                       v-else-if="context.verification_status === 'verified'"

--- a/frontend/src/views/ContextsView.vue
+++ b/frontend/src/views/ContextsView.vue
@@ -99,11 +99,18 @@ const navigateToDetail = (id: string) => {
               </BaseBadge>
               <div class="badge-group">
                 <BaseBadge
-                  v-if="context.verification_status === 'pending'"
+                  v-if="context.verification_status === 'pending' && !context.has_linked_document"
                   variant="warning"
                   size="sm"
                 >
-                  {{ t("context.verificationPending") }}
+                  {{ t("context.verificationDocumentRequired") }}
+                </BaseBadge>
+                <BaseBadge
+                  v-else-if="context.verification_status === 'pending' && context.has_linked_document"
+                  variant="info"
+                  size="sm"
+                >
+                  {{ t("context.verificationAwaitingReview") }}
                 </BaseBadge>
                 <BaseBadge
                   v-else-if="context.verification_status === 'verified'"


### PR DESCRIPTION
## Summary

split the single "Verification pending" badge into two states: "Document required" (warning, no document linked) and "Awaiting review" (info, document linked)
Add missing `verification.status.expired` i18n key to both locale files (was rendering raw key path in sidebar badge)

## Test plan

- [x] Backend: 751 tests pass, TypeScript compilation clean
- [x] Create a legal/healthcare context without uploading a document -> badge reads "Document required"
- [x] Upload and link a document -> badge changes to "Awaiting review"
- [x] Admin approves -> badge shows "Verified"
- [x] Expired context shows "Expired" in sidebar badge (not raw key)