### PR TITLE
Fix dark mode contrast on OAuth consent screen

### DIFF
--- a/frontend/src/views/OAuthConsentView.vue
+++ b/frontend/src/views/OAuthConsentView.vue
@@ -264,7 +264,7 @@ async function handleDecision(decision: "allow" | "deny") {
   margin: 0 auto;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  background-color: white;
+  background-color: var(--bg-secondary);
   box-shadow: var(--shadow-sm);
 }
 
@@ -365,12 +365,12 @@ async function handleDecision(decision: "allow" | "deny") {
 }
 
 .btn-secondary {
-  background-color: white;
-  color: var(--color-gray-700);
-  border: 1px solid var(--color-gray-300);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
 }
 
 .btn-secondary:hover {
-  background-color: var(--color-gray-50);
+  background-color: var(--bg-secondary);
 }
 </style>


### PR DESCRIPTION
## Summary
Replace hardcoded `white` backgrounds in `.client-logo` and `.btn-secondary` with CSS vars
Replace hardcoded `--color-gray-700` text color with `--text-primary`
Replace hardcoded `--color-gray-300` border with `--border-primary`

## Context
Participant 3 during usability testing reported grey-over-white text on the OAuth consent screen in dark mode. I had to intervene and manually select text for the participant to read it.

## Test plan
- [ ] Toggle dark mode on `/oauth/authorize` consent screen
- [ ] Verify Deny button has proper contrast (not white-on-dark background)
- [ ] Verify hover states work correctly in both light and dark themes

Resolves MAS-103.