### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_API_VERSION: string;
+  readonly VITE_CF_ANALYTICS_TOKEN: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -23,3 +23,14 @@ app.use(router);
 app.use(i18n);
 
 app.mount("#app");
+
+// Cloudflare Web Analytics: load beacon only when token is configured.
+// The token is empty in local development and set via render.yaml in production.
+const cfToken = import.meta.env.VITE_CF_ANALYTICS_TOKEN;
+if (cfToken) {
+  const script = document.createElement("script");
+  script.defer = true;
+  script.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  script.dataset.cfBeacon = JSON.stringify({ token: cfToken });
+  document.body.appendChild(script);
+}

--- a/render.yaml
+++ b/render.yaml
@@ -177,3 +177,5 @@ services:
         value: "https://identity-api-9hpf.onrender.com"
       - key: VITE_API_VERSION
         value: "v1"
+      - key: VITE_CF_ANALYTICS_TOKEN
+        value: "aa221c2cfa4e4a069739593fad27f0ee"


### PR DESCRIPTION
## Summary
- Inject Cloudflare Web Analytics beacon dynamically in `main.ts` when `VITE_CF_ANALYTICS_TOKEN` is set
- Token is empty in local dev (no script loaded), set in production via `render.yaml`
- Add type declaration for the new env var in `env.d.ts`

## Test plan
- [x] Run `npm run dev` locally, verify no request to `cloudflareinsights.com` in DevTools Network tab
- [x] Set `VITE_CF_ANALYTICS_TOKEN=test` in a local `.env`, restart dev, confirm beacon loads
- [x] After deploying to Render, verify the script in production page source
- [x] Re-sync the Render blueprint to propagate `VITE_CF_ANALYTICS_TOKEN`