### PR TITLE
Add backend performance benchmarking scripts

### DIFF
--- a/architecture/participant-results-body.qmd
+++ b/architecture/participant-results-body.qmd
@@ -1,0 +1,797 @@
+
+## Participant P1
+
+Participant ID: **P1** \hfill Date: **2026-02-23**
+
+### Section A: Demographics
+
+**1. Age range:**
+
+- $\square$ 18-24
+- $\square$ 25-34
+- $\checkmark$ 35-44
+- $\square$ 45-54
+- $\square$ 55+
+
+**2. How would you rate your general technical literacy?**
+
+- $\checkmark$ Beginner (I use basic apps like email and social media)
+- $\square$ Intermediate (I configure settings and install software)
+- $\square$ Advanced (I write code or manage technical systems)
+
+**3. Have you previously used any identity or profile management tool?**
+
+- $\checkmark$ Never
+- $\square$ Occasionally
+- $\square$ Regularly
+
+### Section B: System Usability Scale
+
+After completing the test tasks, rate each statement on a scale from 1 to 5.
+
+**1** = Strongly Disagree | **2** = Disagree | **3** = Neutral | **4** = Agree | **5** = Strongly Agree
+
+| # | Statement | 1 | 2 | 3 | 4 | 5 |
+|---|-----------|:-:|:-:|:-:|:-:|:-:|
+| 1 | I think that I would like to use this system frequently. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+| 2 | I found the system unnecessarily complex. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 3 | I thought the system was easy to use. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 4 | I think that I would need the support of a technical person to be able to use this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 5 | I found the various functions in this system were well integrated. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 6 | I thought there was too much inconsistency in this system. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 7 | I would imagine that most people would learn to use this system very quickly. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+| 8 | I found the system very cumbersome to use. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 9 | I felt very confident using the system. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 10 | I needed to learn a lot of things before I could get going with this system. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+
+### Section C: Open-Ended Feedback
+
+**1.** What, if anything, did you find confusing or difficult?
+
+> I didn't realize right away that I needed to verify my email, since I missed the initial message.
+
+**2.** What would you change about the system if you could change one thing?
+
+> The Italian localisation is incomplete. Several interface strings remain in English while others appear in Italian.
+
+**3.** Any additional comments?
+
+> I like the dark/light theme choice.
+
+\newpage
+
+### Scoring Reference {.unnumbered}
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 4 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 6 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 7 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 8 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 10 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+
+Sum of contributions: **28**
+
+SUS Score (sum × 2.5): **70.0**
+
+Grade (Bangor et al., 2009): **B (above average)**
+
+\newpage
+
+Participant ID: **P1** \hfill Date: **2026-02-23** \hfill Facilitator: **Luca C.**
+
+### Task Metrics
+
+| Task | Done? | Time | Errors | Observations |
+|------|:-----:|:----:|:------:|--------------|
+| 1. Registration and profile creation | Y | 3:20 | 0 | User used custom email/password |
+| 2. Create professional context profile | Y | 8:12 | 0 | Decided to go with a Legal context, it took a bit to upload the document |
+| 3. Authorize third-party application (OAuth) | Y | 9:03 | 0 |  |
+| 4. View and revoke OAuth access | N | 10:14 | 1 | Missing implementation - not showing in the UI |
+| 5. Export personal data (optional) | N/A | - | - | User was not available to continue |
+
+### Facilitator Interventions
+
+| Task | Time into task | Intervention description |
+|------|:--------------:|--------------------------|
+| Registration | 0:45 | Confirmed they should verify the email and login again |
+| Revoking OAuth access | 0:15 | Asked the user to stop because there was no OAuth connected apps in the context view |
+
+### Think-Aloud Observations
+
+- User missed the description of the verification flow via email due to quick redirect to the login page.
+- The user was using a tablet, and was struggling to find the menu at the beginning, but they figured it out on their own.
+- User was particularly happy to switch between the light and the dark theme.
+- User complained about the lack of correct Italian translations in the whole interface.
+
+\newpage
+
+### SUS Score Calculation
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 4 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 6 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 7 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 8 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 10 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+
+Sum of contributions: **28**
+
+SUS Score (sum × 2.5): **70.0**
+
+Grade (Bangor et al., 2009): **B (above average)**
+
+\newpage
+
+## Participant P2
+
+Participant ID: **P2** \hfill Date: **2026-02-23**
+
+### Section A: Demographics
+
+**1. Age range:**
+
+- $\square$ 18-24
+- $\checkmark$ 25-34
+- $\square$ 35-44
+- $\square$ 45-54
+- $\square$ 55+
+
+**2. How would you rate your general technical literacy?**
+
+- $\square$ Beginner (I use basic apps like email and social media)
+- $\checkmark$ Intermediate (I configure settings and install software)
+- $\square$ Advanced (I write code or manage technical systems)
+
+**3. Have you previously used any identity or profile management tool?**
+
+- $\square$ Never
+- $\checkmark$ Occasionally
+- $\square$ Regularly
+
+### Section B: System Usability Scale
+
+After completing the test tasks, rate each statement on a scale from 1 to 5.
+
+**1** = Strongly Disagree | **2** = Disagree | **3** = Neutral | **4** = Agree | **5** = Strongly Agree
+
+| # | Statement | 1 | 2 | 3 | 4 | 5 |
+|---|-----------|:-:|:-:|:-:|:-:|:-:|
+| 1 | I think that I would like to use this system frequently. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 2 | I found the system unnecessarily complex. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 3 | I thought the system was easy to use. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 4 | I think that I would need the support of a technical person to be able to use this system. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 5 | I found the various functions in this system were well integrated. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+| 6 | I thought there was too much inconsistency in this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 7 | I would imagine that most people would learn to use this system very quickly. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 8 | I found the system very cumbersome to use. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 9 | I felt very confident using the system. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 10 | I needed to learn a lot of things before I could get going with this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+
+### Section C: Open-Ended Feedback
+
+**1.** What, if anything, did you find confusing or difficult?
+
+> (No response)
+
+**2.** What would you change about the system if you could change one thing?
+
+> (No response)
+
+**3.** Any additional comments?
+
+> It's very fast.
+
+\newpage
+
+### Scoring Reference {.unnumbered}
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 4 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 5 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 6 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 8 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 10 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+
+Sum of contributions: **32**
+
+SUS Score (sum × 2.5): **80.0**
+
+Grade (Bangor et al., 2009): **B (above average)**
+
+\newpage
+
+Participant ID: **P2** \hfill Date: **2026-02-23** \hfill Facilitator: **Luca C.**
+
+### Task Metrics
+
+| Task | Done? | Time | Errors | Observations |
+|------|:-----:|:----:|:------:|--------------|
+| 1. Registration and profile creation | Y | 0:35 | 0 | User used Google to login |
+| 2. Create professional context profile | Y | 3:50 | 0 |  |
+| 3. Authorize third-party application (OAuth) | Y | 5:25 | 1 | Not visible avatar in consent flow confused the user |
+| 4. View and revoke OAuth access | N | - | 1 | Confirmed bug of missing implementation |
+| 5. Export personal data (optional) | Y | - | 0 | User was not given detailed instructions |
+
+### Facilitator Interventions
+
+No interventions were needed during this session.
+
+### Think-Aloud Observations
+
+- User mentioned the system was very fast and simple to use. No intervention needed, they seemed used to such systems.
+
+\newpage
+
+### SUS Score Calculation
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 4 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 5 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 6 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 8 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 10 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+
+Sum of contributions: **32**
+
+SUS Score (sum × 2.5): **80.0**
+
+Grade (Bangor et al., 2009): **B (above average)**
+
+\newpage
+
+## Participant P3
+
+Participant ID: **P3** \hfill Date: **2026-03-03**
+
+### Section A: Demographics
+
+**1. Age range:**
+
+- $\square$ 18-24
+- $\square$ 25-34
+- $\checkmark$ 35-44
+- $\square$ 45-54
+- $\square$ 55+
+
+**2. How would you rate your general technical literacy?**
+
+- $\checkmark$ Beginner (I use basic apps like email and social media)
+- $\square$ Intermediate (I configure settings and install software)
+- $\square$ Advanced (I write code or manage technical systems)
+
+**3. Have you previously used any identity or profile management tool?**
+
+- $\checkmark$ Never
+- $\square$ Occasionally
+- $\square$ Regularly
+
+### Section B: System Usability Scale
+
+After completing the test tasks, rate each statement on a scale from 1 to 5.
+
+**1** = Strongly Disagree | **2** = Disagree | **3** = Neutral | **4** = Agree | **5** = Strongly Agree
+
+| # | Statement | 1 | 2 | 3 | 4 | 5 |
+|---|-----------|:-:|:-:|:-:|:-:|:-:|
+| 1 | I think that I would like to use this system frequently. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 2 | I found the system unnecessarily complex. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 3 | I thought the system was easy to use. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 4 | I think that I would need the support of a technical person to be able to use this system. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 5 | I found the various functions in this system were well integrated. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 6 | I thought there was too much inconsistency in this system. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 7 | I would imagine that most people would learn to use this system very quickly. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 8 | I found the system very cumbersome to use. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 9 | I felt very confident using the system. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 10 | I needed to learn a lot of things before I could get going with this system. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+
+### Section C: Open-Ended Feedback
+
+**1.** What, if anything, did you find confusing or difficult?
+
+> The reason the danger zone is dangerous isn't explained.
+
+**2.** What would you change about the system if you could change one thing?
+
+> Some text is difficult to read because there isn't enough contrast.
+
+**3.** Any additional comments?
+
+> (No response)
+
+\newpage
+
+### Scoring Reference {.unnumbered}
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 4 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 6 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 8 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 10 (negative) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 5 -- 3 = **2** |
+
+Sum of contributions: **37**
+
+SUS Score (sum × 2.5): **92.5**
+
+Grade (Bangor et al., 2009): **A (excellent)**
+
+\newpage
+
+Participant ID: **P3** \hfill Date: **2026-03-03** \hfill Facilitator: **Luca C.**
+
+### Task Metrics
+
+| Task | Done? | Time | Errors | Observations |
+|------|:-----:|:----:|:------:|--------------|
+| 1. Registration and profile creation | Y | 2:34 | 0 | Complete profile creation, asked for more languages |
+| 2. Create professional context profile | Y | 4:48 | 0 |  |
+| 3. Authorize third-party application (OAuth) | Y | 6:12 | 0 |  |
+| 4. View and revoke OAuth access | Y | 7:15 | 0 |  |
+| 5. Export personal data (optional) | Y | 8:37 | 0 | They did it but do not know how to import eventually again |
+
+### Facilitator Interventions
+
+| Task | Time into task | Intervention description |
+|------|:--------------:|--------------------------|
+| OAuth authorization | - | Had to select the text manually because it was not readable |
+
+### Think-Aloud Observations
+
+- User complains about not understanding the danger zone.
+- User was not able to see some grey over white text when using dark theme on the consent screen.
+
+\newpage
+
+### SUS Score Calculation
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 4 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 6 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 8 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 10 (negative) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 5 -- 3 = **2** |
+
+Sum of contributions: **37**
+
+SUS Score (sum × 2.5): **92.5**
+
+Grade (Bangor et al., 2009): **A (excellent)**
+
+\newpage
+
+## Participant P4
+
+Participant ID: **P4** \hfill Date: **2026-03-04**
+
+### Section A: Demographics
+
+**1. Age range:**
+
+- $\square$ 18-24
+- $\checkmark$ 25-34
+- $\square$ 35-44
+- $\square$ 45-54
+- $\square$ 55+
+
+**2. How would you rate your general technical literacy?**
+
+- $\square$ Beginner (I use basic apps like email and social media)
+- $\square$ Intermediate (I configure settings and install software)
+- $\checkmark$ Advanced (I write code or manage technical systems)
+
+**3. Have you previously used any identity or profile management tool?**
+
+- $\square$ Never
+- $\square$ Occasionally
+- $\checkmark$ Regularly
+
+### Section B: System Usability Scale
+
+After completing the test tasks, rate each statement on a scale from 1 to 5.
+
+**1** = Strongly Disagree | **2** = Disagree | **3** = Neutral | **4** = Agree | **5** = Strongly Agree
+
+| # | Statement | 1 | 2 | 3 | 4 | 5 |
+|---|-----------|:-:|:-:|:-:|:-:|:-:|
+| 1 | I think that I would like to use this system frequently. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 2 | I found the system unnecessarily complex. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 3 | I thought the system was easy to use. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 4 | I think that I would need the support of a technical person to be able to use this system. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 5 | I found the various functions in this system were well integrated. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 6 | I thought there was too much inconsistency in this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 7 | I would imagine that most people would learn to use this system very quickly. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 8 | I found the system very cumbersome to use. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+| 9 | I felt very confident using the system. | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ |
+| 10 | I needed to learn a lot of things before I could get going with this system. | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ |
+
+### Section C: Open-Ended Feedback
+
+**1.** What, if anything, did you find confusing or difficult?
+
+> Nothing was confusing. The flow felt natural and well-structured.
+
+**2.** What would you change about the system if you could change one thing?
+
+> I'd add keyboard shortcuts for power users.
+
+**3.** Any additional comments?
+
+> Good separation of concerns between contexts. Clean UI.
+
+\newpage
+
+### Scoring Reference {.unnumbered}
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 4 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 6 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 8 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 10 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+
+Sum of contributions: **38**
+
+SUS Score (sum × 2.5): **95.0**
+
+Grade (Bangor et al., 2009): **A (excellent)**
+
+\newpage
+
+Participant ID: **P4** \hfill Date: **2026-03-04** \hfill Facilitator: **Luca**
+
+### Task Metrics
+
+| Task | Done? | Time | Errors | Observations |
+|------|:-----:|:----:|:------:|--------------|
+| 1. Registration and profile creation | Y | 1:42 | 0 | Went straight to registration, no hesitation |
+| 2. Create professional context profile | Y | 1:15 | 0 | Found context creation immediately |
+| 3. Authorize third-party application (OAuth) | Y | 1:08 | 0 | Read scopes carefully, selected correct context |
+| 4. View and revoke OAuth access | Y | 0:45 | 0 | Navigated to consents page directly |
+| 5. Export personal data (optional) | Y | 0:52 | 0 | Found export in settings without help |
+
+### Facilitator Interventions
+
+No interventions were needed during this session.
+
+### Think-Aloud Observations
+
+- "This is pretty standard registration flow, nothing unusual."
+- "Oh nice, I can have separate identities - that's useful for work vs personal."
+- "The OAuth consent screen is clear, I can see exactly what Portfolio App wants."
+- "Revoking is where I'd expect it, under authorized apps."
+
+\newpage
+
+### SUS Score Calculation
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 2 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 4 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 6 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 8 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+| 9 (positive) | $\square$ | $\square$ | $\square$ | $\square$ | $\checkmark$ | 5 -- 1 = **4** |
+| 10 (negative) | $\checkmark$ | $\square$ | $\square$ | $\square$ | $\square$ | 5 -- 1 = **4** |
+
+Sum of contributions: **38**
+
+SUS Score (sum × 2.5): **95.0**
+
+Grade (Bangor et al., 2009): **A (excellent)**
+
+\newpage
+
+## Participant P5
+
+Participant ID: **P5** \hfill Date: **2026-03-06**
+
+### Section A: Demographics
+
+**1. Age range:**
+
+- $\square$ 18-24
+- $\square$ 25-34
+- $\square$ 35-44
+- $\checkmark$ 45-54
+- $\square$ 55+
+
+**2. How would you rate your general technical literacy?**
+
+- $\checkmark$ Beginner (I use basic apps like email and social media)
+- $\square$ Intermediate (I configure settings and install software)
+- $\square$ Advanced (I write code or manage technical systems)
+
+**3. Have you previously used any identity or profile management tool?**
+
+- $\checkmark$ Never
+- $\square$ Occasionally
+- $\square$ Regularly
+
+### Section B: System Usability Scale
+
+After completing the test tasks, rate each statement on a scale from 1 to 5.
+
+**1** = Strongly Disagree | **2** = Disagree | **3** = Neutral | **4** = Agree | **5** = Strongly Agree
+
+| # | Statement | 1 | 2 | 3 | 4 | 5 |
+|---|-----------|:-:|:-:|:-:|:-:|:-:|
+| 1 | I think that I would like to use this system frequently. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 2 | I found the system unnecessarily complex. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 3 | I thought the system was easy to use. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 4 | I think that I would need the support of a technical person to be able to use this system. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 5 | I found the various functions in this system were well integrated. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+| 6 | I thought there was too much inconsistency in this system. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+| 7 | I would imagine that most people would learn to use this system very quickly. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 8 | I found the system very cumbersome to use. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 9 | I felt very confident using the system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 10 | I needed to learn a lot of things before I could get going with this system. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+
+### Section C: Open-Ended Feedback
+
+**1.** What, if anything, did you find confusing or difficult?
+
+> The OAuth authorization screen was confusing. I didn't understand what "scopes" meant. Also finding where to revoke access was hard.
+
+**2.** What would you change about the system if you could change one thing?
+
+> Simpler language. Instead of "scopes" say "what data the app can see."
+
+**3.** Any additional comments?
+
+> The concept of separate identities is interesting but needs a better introduction for non-technical users.
+
+\newpage
+
+### Scoring Reference {.unnumbered}
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 2 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+| 3 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 4 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+| 5 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 6 (negative) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 5 -- 3 = **2** |
+| 7 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 8 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+| 9 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 10 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+
+Sum of contributions: **12**
+
+SUS Score (sum × 2.5): **30.0**
+
+Grade (Bangor et al., 2009): **F (poor)**
+
+\newpage
+
+Participant ID: **P5** \hfill Date: **2026-03-06** \hfill Facilitator: **Luca**
+
+### Task Metrics
+
+| Task | Done? | Time | Errors | Observations |
+|------|:-----:|:----:|:------:|--------------|
+| 1. Registration and profile creation | Y | 3:48 | 2 | Tried to submit without filling email. Confused by verification step. |
+| 2. Create professional context profile | Y | 3:12 | 1 | Initially looked for "new profile" in top menu, took a while to find context creation |
+| 3. Authorize third-party application (OAuth) | Y | 2:45 | 2 | Did not read scopes initially, clicked approve then hesitated. Selected wrong context first. |
+| 4. View and revoke OAuth access | N | 3:00 | 3 | Could not find authorized apps page. Looked in profile settings, account settings. Time expired. |
+| 5. Export personal data (optional) | - | - | - | Skipped (participant was fatigued after Task 4 difficulty) |
+
+### Facilitator Interventions
+
+| Task | Time into task | Intervention description |
+|------|:--------------:|--------------------------|
+| 1 | 2:30 | Guided participant to check Mailpit for verification email |
+| 4 | 2:15 | Hinted that authorized apps might be under a different menu section |
+
+### Think-Aloud Observations
+
+- "Where do I verify my email? I don't see any confirmation."
+- "What's a context profile? Is that like a second account?"
+- "OAuth - I'm not sure what scopes means. What is profile:read?"
+- "I want to remove the app's access but I can't find where. Maybe under settings?"
+- "This is a bit overwhelming, there are many options."
+
+\newpage
+
+### SUS Score Calculation
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 2 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+| 3 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 4 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+| 5 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 6 (negative) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 5 -- 3 = **2** |
+| 7 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 8 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+| 9 (positive) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 2 -- 1 = **1** |
+| 10 (negative) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 5 -- 4 = **1** |
+
+Sum of contributions: **12**
+
+SUS Score (sum × 2.5): **30.0**
+
+Grade (Bangor et al., 2009): **F (poor)**
+
+\newpage
+
+## Participant P6
+
+Participant ID: **P6** \hfill Date: **2026-03-09**
+
+### Section A: Demographics
+
+**1. Age range:**
+
+- $\square$ 18-24
+- $\checkmark$ 25-34
+- $\square$ 35-44
+- $\square$ 45-54
+- $\square$ 55+
+
+**2. How would you rate your general technical literacy?**
+
+- $\square$ Beginner (I use basic apps like email and social media)
+- $\checkmark$ Intermediate (I configure settings and install software)
+- $\square$ Advanced (I write code or manage technical systems)
+
+**3. Have you previously used any identity or profile management tool?**
+
+- $\square$ Never
+- $\checkmark$ Occasionally
+- $\square$ Regularly
+
+### Section B: System Usability Scale
+
+After completing the test tasks, rate each statement on a scale from 1 to 5.
+
+**1** = Strongly Disagree | **2** = Disagree | **3** = Neutral | **4** = Agree | **5** = Strongly Agree
+
+| # | Statement | 1 | 2 | 3 | 4 | 5 |
+|---|-----------|:-:|:-:|:-:|:-:|:-:|
+| 1 | I think that I would like to use this system frequently. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 2 | I found the system unnecessarily complex. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 3 | I thought the system was easy to use. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 4 | I think that I would need the support of a technical person to be able to use this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 5 | I found the various functions in this system were well integrated. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 6 | I thought there was too much inconsistency in this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 7 | I would imagine that most people would learn to use this system very quickly. | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ |
+| 8 | I found the system very cumbersome to use. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+| 9 | I felt very confident using the system. | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ |
+| 10 | I needed to learn a lot of things before I could get going with this system. | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ |
+
+### Section C: Open-Ended Feedback
+
+**1.** What, if anything, did you find confusing or difficult?
+
+> Finding authorized apps took a moment. I expected it under profile or settings, not context.
+
+**2.** What would you change about the system if you could change one thing?
+
+> Move the "authorized apps" link to the profile page or add a shortcut there.
+
+**3.** Any additional comments?
+
+> Overall a clean experience. The context concept is well implemented.
+
+\newpage
+
+### Scoring Reference {.unnumbered}
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 2 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 4 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 6 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 8 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 9 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 10 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+
+Sum of contributions: **29**
+
+SUS Score (sum × 2.5): **72.5**
+
+Grade (Bangor et al., 2009): **B (above average)**
+
+\newpage
+
+Participant ID: **P6** \hfill Date: **2026-03-09** \hfill Facilitator: **Luca**
+
+### Task Metrics
+
+| Task | Done? | Time | Errors | Observations |
+|------|:-----:|:----:|:------:|--------------|
+| 1. Registration and profile creation | Y | 2:10 | 0 | Smooth registration, noticed the password strength indicator |
+| 2. Create professional context profile | Y | 2:05 | 0 | Found context creation in sidebar, completed without issues |
+| 3. Authorize third-party application (OAuth) | Y | 1:55 | 1 | Read scopes but initially confused by PKCE redirect behavior |
+| 4. View and revoke OAuth access | Y | 2:20 | 1 | First went to profile page instead of consents. Found it on second try. |
+| 5. Export personal data (optional) | Y | 1:30 | 0 | Located export feature under privacy/data section |
+
+### Facilitator Interventions
+
+No interventions were needed during this session.
+
+### Think-Aloud Observations
+
+- "Registration is straightforward, similar to what I'm used to."
+- "Okay, so a context is like a persona. That makes sense for work vs personal."
+- "The redirect after OAuth approval was a bit jarring, but it worked."
+- "Hmm, where are my authorized apps? Not on the profile page… ah, there it is under security."
+- "Data export - I'd expect this under privacy. Yes, found it."
+
+\newpage
+
+### SUS Score Calculation
+
+| Item | 1 | 2 | 3 | 4 | 5 | Contribution |
+|------|:-:|:-:|:-:|:-:|:-:|-------------|
+| 1 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 2 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 3 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 4 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 5 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 6 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 7 (positive) | $\square$ | $\square$ | $\square$ | $\checkmark$ | $\square$ | 4 -- 1 = **3** |
+| 8 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+| 9 (positive) | $\square$ | $\square$ | $\checkmark$ | $\square$ | $\square$ | 3 -- 1 = **2** |
+| 10 (negative) | $\square$ | $\checkmark$ | $\square$ | $\square$ | $\square$ | 5 -- 2 = **3** |
+
+Sum of contributions: **29**
+
+SUS Score (sum × 2.5): **72.5**
+
+Grade (Bangor et al., 2009): **B (above average)**
+
+\newpage

--- a/backend/scripts/benchmark.sh
+++ b/backend/scripts/benchmark.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # benchmark.sh - HTTP load testing with hey
 #
-# Prerequisites: brew install hey
-#
 # Usage:
 #   ./scripts/benchmark.sh                    # defaults: 200 requests, 10 concurrent
 #   ./scripts/benchmark.sh -n 500 -c 20       # custom request count and concurrency
@@ -18,8 +16,8 @@ DURATION=""
 RUN_AUTH=false
 
 # Seed data IDs
-SARAH_USER_ID="00000000-0000-0000-0000-000000000001"
-PROF_CONTEXT_ID="20000000-0000-0000-0000-000000000001"
+SARAH_USER_ID="11111111-1111-1111-1111-111111111111"
+PROF_CONTEXT_ID="cccccccc-0001-0001-0001-cccccccccccc"
 
 usage() {
     echo "Usage: $0 [-n requests] [-c concurrency] [-t duration] [--auth]"
@@ -45,7 +43,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if ! command -v hey &> /dev/null; then
-    echo "Error: hey is not installed. Install with: brew install hey"
+    echo "Error: hey is not installed. Install following https://github.com/rakyll/hey?tab=readme-ov-file#installation"
     exit 1
 fi
 
@@ -57,9 +55,8 @@ else
     HEY_ARGS="$HEY_ARGS -n $REQUESTS"
 fi
 
-echo "============================================"
 echo "Backend Benchmark Suite"
-echo "============================================"
+echo ""
 echo "Base URL:    $BASE_URL"
 if [[ -n "$DURATION" ]]; then
     echo "Duration:    $DURATION"
@@ -68,32 +65,31 @@ else
 fi
 echo "Concurrency: $CONCURRENCY"
 echo "Auth tests:  $RUN_AUTH"
-echo "============================================"
 echo ""
 
 # --- Unauthenticated endpoints ---
 
 echo ">>> GET /health (baseline, no DB query)"
-echo "--------------------------------------------"
-# shellcheck disable=SC2086
+echo "---------------------------------------"
+
 hey $HEY_ARGS "$BASE_URL/health"
 echo ""
 
-echo ">>> GET /health/detailed (includes DB round-trip)"
-echo "--------------------------------------------"
-# shellcheck disable=SC2086
-hey $HEY_ARGS "$BASE_URL/health/detailed"
-echo ""
+# echo ">>> GET /health/detailed (includes DB round-trip)"
+# echo "-------------------------------------------------"
+# # shellcheck disable=SC2086
+# hey $HEY_ARGS "$BASE_URL/health/detailed"
+# echo ""
 
 # --- Authenticated endpoints ---
 
 if [[ "$RUN_AUTH" == true ]]; then
     echo ">>> POST /api/v1/auth/login (Argon2id hashing)"
-    echo "--------------------------------------------"
+    echo "----------------------------------------------"
     # shellcheck disable=SC2086
     hey $HEY_ARGS -m POST \
         -H "Content-Type: application/json" \
-        -d '{"email":"sarah.chen@example.com","password":"SecurePass123!"}' \
+        -d '{"email":"sarah.chen@example.com","password":"TestPassword123!"}' \
         "$BASE_URL/api/v1/auth/login"
     echo ""
 
@@ -101,7 +97,7 @@ if [[ "$RUN_AUTH" == true ]]; then
     echo "Obtaining auth token for authenticated endpoints..."
     TOKEN=$(curl -s -X POST "$BASE_URL/api/v1/auth/login" \
         -H "Content-Type: application/json" \
-        -d '{"email":"sarah.chen@example.com","password":"SecurePass123!"}' \
+        -d '{"email":"sarah.chen@example.com","password":"TestPassword123!"}' \
         | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)
 
     if [[ -z "$TOKEN" ]]; then
@@ -125,6 +121,4 @@ if [[ "$RUN_AUTH" == true ]]; then
     fi
 fi
 
-echo "============================================"
 echo "Benchmark complete."
-echo "============================================"

--- a/backend/scripts/benchmark.sh
+++ b/backend/scripts/benchmark.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# benchmark.sh - HTTP load testing with hey
+#
+# Prerequisites: brew install hey
+#
+# Usage:
+#   ./scripts/benchmark.sh                    # defaults: 200 requests, 10 concurrent
+#   ./scripts/benchmark.sh -n 500 -c 20       # custom request count and concurrency
+#   ./scripts/benchmark.sh -t 30s             # sustained load for 30 seconds
+#   ./scripts/benchmark.sh --auth             # include authenticated endpoints
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8000}"
+REQUESTS=200
+CONCURRENCY=10
+DURATION=""
+RUN_AUTH=false
+
+# Seed data IDs
+SARAH_USER_ID="00000000-0000-0000-0000-000000000001"
+PROF_CONTEXT_ID="20000000-0000-0000-0000-000000000001"
+
+usage() {
+    echo "Usage: $0 [-n requests] [-c concurrency] [-t duration] [--auth]"
+    echo ""
+    echo "Options:"
+    echo "  -n NUM      Number of requests (default: 200)"
+    echo "  -c NUM      Concurrency level (default: 10)"
+    echo "  -t DURATION Sustained load duration, e.g. 30s (overrides -n)"
+    echo "  --auth      Include authenticated endpoints (requires running backend with seed data)"
+    echo "  -h          Show this help"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n) REQUESTS="$2"; shift 2 ;;
+        -c) CONCURRENCY="$2"; shift 2 ;;
+        -t) DURATION="$2"; shift 2 ;;
+        --auth) RUN_AUTH=true; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if ! command -v hey &> /dev/null; then
+    echo "Error: hey is not installed. Install with: brew install hey"
+    exit 1
+fi
+
+# Build hey arguments
+HEY_ARGS="-c $CONCURRENCY"
+if [[ -n "$DURATION" ]]; then
+    HEY_ARGS="$HEY_ARGS -z $DURATION"
+else
+    HEY_ARGS="$HEY_ARGS -n $REQUESTS"
+fi
+
+echo "============================================"
+echo "Backend Benchmark Suite"
+echo "============================================"
+echo "Base URL:    $BASE_URL"
+if [[ -n "$DURATION" ]]; then
+    echo "Duration:    $DURATION"
+else
+    echo "Requests:    $REQUESTS"
+fi
+echo "Concurrency: $CONCURRENCY"
+echo "Auth tests:  $RUN_AUTH"
+echo "============================================"
+echo ""
+
+# --- Unauthenticated endpoints ---
+
+echo ">>> GET /health (baseline, no DB query)"
+echo "--------------------------------------------"
+# shellcheck disable=SC2086
+hey $HEY_ARGS "$BASE_URL/health"
+echo ""
+
+echo ">>> GET /health/detailed (includes DB round-trip)"
+echo "--------------------------------------------"
+# shellcheck disable=SC2086
+hey $HEY_ARGS "$BASE_URL/health/detailed"
+echo ""
+
+# --- Authenticated endpoints ---
+
+if [[ "$RUN_AUTH" == true ]]; then
+    echo ">>> POST /api/v1/auth/login (Argon2id hashing)"
+    echo "--------------------------------------------"
+    # shellcheck disable=SC2086
+    hey $HEY_ARGS -m POST \
+        -H "Content-Type: application/json" \
+        -d '{"email":"sarah.chen@example.com","password":"SecurePass123!"}' \
+        "$BASE_URL/api/v1/auth/login"
+    echo ""
+
+    # Obtain a token for authenticated GET requests
+    echo "Obtaining auth token for authenticated endpoints..."
+    TOKEN=$(curl -s -X POST "$BASE_URL/api/v1/auth/login" \
+        -H "Content-Type: application/json" \
+        -d '{"email":"sarah.chen@example.com","password":"SecurePass123!"}' \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)
+
+    if [[ -z "$TOKEN" ]]; then
+        echo "Warning: could not obtain auth token. Skipping authenticated GET endpoints."
+    else
+        echo ">>> GET /api/v1/profiles/{id}/contexts/{id}/resolved (inheritance engine)"
+        echo "--------------------------------------------"
+        # shellcheck disable=SC2086
+        hey $HEY_ARGS \
+            -H "Authorization: Bearer $TOKEN" \
+            "$BASE_URL/api/v1/profiles/$SARAH_USER_ID/contexts/$PROF_CONTEXT_ID/resolved"
+        echo ""
+
+        echo ">>> GET /api/v1/profiles/{id}/contexts (list contexts)"
+        echo "--------------------------------------------"
+        # shellcheck disable=SC2086
+        hey $HEY_ARGS \
+            -H "Authorization: Bearer $TOKEN" \
+            "$BASE_URL/api/v1/profiles/$SARAH_USER_ID/contexts"
+        echo ""
+    fi
+fi
+
+echo "============================================"
+echo "Benchmark complete."
+echo "============================================"

--- a/draft-report.qmd
+++ b/draft-report.qmd
@@ -1383,7 +1383,7 @@ Status code distribution:  [200] 200 responses
 
 # Appendix E: Usability Testing Results {- #sec-appendix-usability}
 
-{{< include evaluation/participant-results-body.qmd >}}
+{{< include architecture/participant-results-body.qmd >}}
 
 
 # References {-}

--- a/draft-report.qmd
+++ b/draft-report.qmd
@@ -371,7 +371,7 @@ flowchart TB
 
 ## Overview
 
-The implementation comprises approximately 14,600 lines of Python source code across 72 backend modules, approximately 25,200 lines of Vue.js and TypeScript across 115 frontend files, and 16,900 lines of test code across 46 test modules, supported by 751 automated tests achieving 85% code coverage. The database schema spans 19 migration files. Development followed test-driven methodology, with tests written before implementation to ensure coverage, provide executable documentation, and enable safe refactoring. A GitHub Actions CI/CD pipeline enforces lint, type, security, and test quality gates on every push and pull request.
+The implementation comprises approximately 14,600 lines of Python source code across 72 backend modules, approximately 25,500 lines of Vue.js and TypeScript across 115 frontend files, and 17,000 lines of test code across 46 test modules, supported by 755 automated tests achieving 85% code coverage. The database schema spans 19 migration files. Development followed test-driven methodology, with tests written before implementation to ensure coverage, provide executable documentation, and enable safe refactoring. A GitHub Actions CI/CD pipeline enforces lint, type, security, and test quality gates on every push and pull request.
 
 
 ## Project Management
@@ -662,22 +662,22 @@ Web API evaluation differs from machine learning evaluation. Rather than accurac
 
 ## Automated Testing Results
 
-A test suite of 751 automated tests spans unit and integration layers, achieving 85% code coverage across 5,455 statements. Tests are organized across 46 test modules covering all major subsystems.
+A test suite of 755 automated tests spans unit and integration layers, achieving 85% code coverage across 5,458 statements. Tests are organized across 46 test modules covering all major subsystems.
 
 | Test Category | Count | Coverage | Description |
 |--------------|-------|----------|-------------|
-| Context Management | 54 | 93% | Inheritance engine, resolution, endpoints |
-| OAuth System | 117 | 96% | PKCE, tokens, consent, admin |
-| Authentication | 73 | 95% | Registration, login, JWT, lockout |
-| Verification | 82 | 81% | Document upload, review, expiry, linking |
-| Profile Management | 46 | 95% | CRUD operations, repositories |
-| Privacy and Audit | 68 | 99% | Data export, audit trails, soft deletion |
-| Schema Validation | 50 | 96% | Pydantic models, input validation |
-| Infrastructure | 38 | 88% | Database, Redis, configuration |
-| Social Auth | 35 | 98% | OAuth provider integration, token exchange |
-| Encryption | 24 | 96% | Fernet encryption, document security |
-| Admin Operations | 34 | 85% | Client management, user purge, review |
-| Avatar Management | 30 | 96% | Upload, storage, retrieval |
+| OAuth System | 136 | 96% | PKCE, tokens, consent, admin, repositories |
+| Privacy and Audit | 130 | 99% | Data export, audit trails, soft deletion, expiry |
+| Authentication | 88 | 95% | Registration, login, JWT, lockout |
+| Verification | 86 | 81% | Document upload, review, expiry, linking |
+| Context Management | 79 | 93% | Inheritance engine, resolution, verification rules |
+| Profile Management | 64 | 91% | CRUD operations, repositories, models |
+| Avatar and Image | 50 | 96% | Upload, processing, storage, retrieval |
+| Infrastructure | 48 | 88% | Database, Redis, configuration |
+| Social Auth | 25 | 98% | OAuth provider integration, token exchange |
+| Schema Validation | 22 | 96% | Pydantic models, input validation |
+| Admin Operations | 18 | 85% | User management, purge, review |
+| Encryption | 9 | 79% | Fernet encryption, document security |
 
 Critical algorithms achieve near-complete coverage. The context service containing the inheritance engine has 93% coverage with tests validating full overrides, partial overrides with null inheritance, deprecated name filtering, temporal validity checking (HTTP 410 for expired contexts), and language fallback chains. The OAuth service has 96% coverage, with PKCE validation tested across valid verifiers, invalid verifiers, malformed challenges, and timing attack resistance. The privacy service achieves 99% coverage, validating data export formats and soft deletion with retention enforcement.
 
@@ -753,16 +753,20 @@ Code quality is enforced through a GitHub Actions CI/CD pipeline that gates ever
 
 ## Performance Evaluation
 
-Preliminary performance measurements indicate the system meets response time targets:
+Load testing was conducted using `hey` [@rakyll2024hey], an HTTP load generator, sending 200 requests at 10 concurrent connections to both local (Docker Compose with local Supabase) and production (Render standard plan, Supabase Micro, both in Frankfurt) environments. The full benchmark output is reproduced in @sec-appendix-benchmarks.
 
-| Endpoint | p50 | p95 | Target |
-|----------|-----|-----|--------|
-| GET /profiles/{id} | 12ms | 28ms | <50ms |
-| GET /contexts/{id}/resolved | 18ms | 42ms | <100ms |
-| POST /oauth/token | 45ms | 89ms | <200ms |
-| GET /oauth/userinfo | 22ms | 48ms | <100ms |
+| Endpoint | Local p50 | Local p95 | Prod p50 | Prod p95 |
+|----------|-----------|-----------|----------|----------|
+| GET /health (no DB) | 1ms | 22ms | 71ms | 320ms |
+| POST /auth/login | 365ms | 1,217ms | 2,462ms | 2,946ms |
+| GET /contexts/{id}/resolved | 27ms | 38ms | 253ms | 387ms |
+| GET /contexts | 16ms | 25ms | 188ms | 317ms |
 
-The inheritance algorithm's O(n) complexity with typical profiles containing 10-15 fields contributes minimal overhead. Database queries use indexed lookups, avoiding table scans. Redis caching (not yet enabled in measurements) is expected to reduce database load by 80-90% for frequently accessed profiles.
+The health endpoint, which performs no database query, establishes a network baseline. Its 70ms local-to-production delta represents the round-trip from the benchmark client to Render Frankfurt. Subtracting this constant from the database-dependent endpoints isolates server-side processing overhead: context resolution takes approximately 183ms on production versus 27ms locally (6.8x), and context listing takes 118ms versus 16ms (7.4x). Both Render and Supabase are deployed in the Frankfurt region, so this gap reflects Supabase Micro's shared-CPU query execution rather than geographic network distance.
+
+Login latency under concurrency is dominated by Argon2id's deliberate computational cost. Each hash allocates 64 MB (`memory_cost=65536`), so 10 concurrent requests require 640 MB for hashing alone on a 2 GB instance. The resulting 4.2 req/s throughput on production versus 24.2 req/s locally reflects CPU and memory constraints on the Render standard plan (1 shared vCPU, 2 GB RAM) compared to local Apple Silicon hardware. This performance characteristic is a security property rather than a defect: the same cost that slows benchmarks makes credential stuffing attacks computationally infeasible.
+
+The inheritance algorithm's O(n) complexity with typical profiles containing 10-15 fields contributes minimal overhead to context resolution. Database queries use indexed lookups, avoiding table scans. Redis caching reduces database load for frequently accessed profiles with a configurable 300-second TTL.
 
 ## Security Evaluation
 
@@ -803,7 +807,7 @@ The interviews reveal a pattern of users who develop elaborate workarounds (mult
 
 Beyond aggregate coverage metrics, analysis of coverage distribution reveals intentional testing priorities. Service layer code achieves the highest coverage: auth_service (95%), oauth_service (96%), context_service (93%), privacy_service (99%), social_auth_service (98%), verification_service (81%), and audit_service (100%). Repository layer code ranges from 65% (verification_repository) to 95% (profile_repository), with uncovered paths primarily consisting of database connection error handling that cannot be reliably triggered in test environments.
 
-The coverage gap in API endpoint modules reflects deliberate prioritization. Authentication endpoints achieve 80% coverage and context endpoints 87%, given their user-facing criticality. The OAuth endpoint module achieves 50% coverage because consent flow UI interactions and redirect handling require browser-level testing beyond unit and integration scope.
+The coverage gap in API endpoint modules reflects deliberate prioritization. Authentication endpoints achieve 76% coverage and context endpoints 88%, given their user-facing criticality. The OAuth endpoint module achieves 72% coverage because consent flow UI interactions and redirect handling require browser-level testing beyond unit and integration scope.
 
 Critical code paths maintain 100% coverage through explicit test requirements. The PKCE verification function, context resolution algorithm, scope-based field filtering, and audit hash chain verification each have dedicated test files ensuring all branches are exercised. These tests serve as executable specification, documenting expected behavior for edge cases that prose documentation might miss.
 
@@ -823,7 +827,7 @@ GDPR-inspired privacy features are now operational. Data export (GDPR Article 15
 
 The evaluation identified several limitations requiring attention before final submission.
 
-Performance testing lacks load testing under concurrent users. While individual request latency meets targets, behavior under 100+ concurrent requests remains unvalidated. Load testing using Locust or k6 will characterize throughput limits and identify bottlenecks under sustained load.
+Load testing with 10 concurrent connections characterizes baseline performance on the production infrastructure. Testing at higher concurrency levels (50-100+ simultaneous users) remains unvalidated and would require horizontal scaling or a higher-tier compute plan to produce meaningful results.
 
 System Usability Scale (SUS) testing was conducted with six participants spanning technical and non-technical backgrounds. The mean SUS score of 73.3 falls within the "acceptable" range, though high variance (SD = 22.2) indicates divergent user experiences. One participant (P5, non-technical background) scored 30, the only score below the acceptability threshold, suggesting that the OAuth consent flow and context management concepts require additional onboarding for users unfamiliar with identity management systems. Five improvement tasks were identified from participant feedback, of which three (dark mode contrast, Italian localization, and consent revocation discoverability) were resolved before submission. The remaining two, email verification visibility and OAuth scope terminology, require further iteration.
 
@@ -847,7 +851,7 @@ The OAuth 2.1 authorization server with mandatory PKCE provides secure third-par
 
 Multilingual name support via JSONB storage accommodates global naming conventions without imposing Western structural assumptions. The four-tier language fallback chain ensures appropriate name display based on requesting application locale. GDPR-inspired privacy features, including data export, soft deletion with 30-day retention, audit logging with hash chain integrity, and identity document verification with automated expiry, are fully operational.
 
-A test suite of 751 automated tests achieving 85% coverage, enforced by a CI/CD pipeline running lint, type, security, and test quality gates, provides confidence in functional correctness. Security measures including Argon2id password hashing, JWT authentication, Row-Level Security policies, and scope-based filtering implement defense in depth against common attack vectors.
+A test suite of 755 automated tests achieving 85% coverage, enforced by a CI/CD pipeline running lint, type, security, and test quality gates, provides confidence in functional correctness. Security measures including Argon2id password hashing, JWT authentication, Row-Level Security policies, and scope-based filtering implement defense in depth against common attack vectors.
 
 ## Broader Implications
 
@@ -1133,8 +1137,8 @@ The following output captures the complete test run with per-module coverage ana
 ============================== test session starts ==============================
 platform linux -- Python 3.12.12, pytest-7.4.4, pluggy-1.6.0
 rootdir: /app
-plugins: anyio-4.12.0, cov-4.1.0, asyncio-0.23.3, Faker-22.0.0
-collected 751 items
+plugins: anyio-4.12.1, cov-4.1.0, asyncio-0.23.3, Faker-22.0.0
+collected 755 items
 
 tests/integration/test_admin_oauth_endpoints.py ...........              [  1%]
 tests/integration/test_admin_user_endpoints.py ........                  [  2%]
@@ -1144,11 +1148,13 @@ tests/integration/test_audit_integration.py .......                      [  5%]
 tests/integration/test_auth_endpoints.py .....................           [  8%]
 tests/integration/test_auth_integration.py ...........                   [  9%]
 tests/integration/test_avatar_endpoints.py ...................           [ 12%]
-tests/integration/test_context_endpoints.py .............................[16%]
+tests/integration/test_context_endpoints.py ............................ [ 16%]
+...                                                                      [ 16%]
 tests/integration/test_context_verification_rule.py ...........          [ 18%]
 tests/integration/test_database_integration.py ..........                [ 19%]
-tests/integration/test_endpoints.py ............                         [ 21%]
-tests/integration/test_oauth_endpoints.py ............................   [ 24%]
+tests/integration/test_endpoints.py ............                         [ 20%]
+tests/integration/test_oauth_endpoints.py .............................. [ 24%]
+                                                                         [ 24%]
 tests/integration/test_privacy_endpoints.py ............                 [ 26%]
 tests/integration/test_social_auth_endpoints.py ...........              [ 27%]
 tests/integration/test_soft_deletion_endpoints.py .............          [ 29%]
@@ -1158,18 +1164,21 @@ tests/unit/test_admin_user_purge.py .....                                [ 33%]
 tests/unit/test_audit_model.py ...............                           [ 35%]
 tests/unit/test_audit_repository.py ..........                           [ 36%]
 tests/unit/test_audit_service.py ........                                [ 37%]
-tests/unit/test_auth_service.py .........................................[42%]
+tests/unit/test_auth_service.py ........................................ [ 42%]
+................                                                         [ 44%]
 tests/unit/test_avatar_service.py .............                          [ 46%]
 tests/unit/test_config.py ..........                                     [ 47%]
-tests/unit/test_context_service.py .......................................[52%]
+tests/unit/test_context_service.py ..................................... [ 52%]
+                                                                         [ 52%]
 tests/unit/test_database.py ..........                                   [ 54%]
 tests/unit/test_document_validation.py ...............                   [ 56%]
 tests/unit/test_encryption.py .........                                  [ 57%]
 tests/unit/test_expiry_tasks.py ..............                           [ 59%]
 tests/unit/test_image_processing.py ..................                   [ 61%]
 tests/unit/test_models.py .............                                  [ 63%]
-tests/unit/test_oauth_repository.py ..................................   [ 67%]
-tests/unit/test_oauth_service.py ........................................[73%]
+tests/unit/test_oauth_repository.py ...................................  [ 67%]
+tests/unit/test_oauth_service.py ....................................... [ 73%]
+.....................                                                    [ 75%]
 tests/unit/test_privacy_service.py .............                         [ 77%]
 tests/unit/test_profile_repository.py .............................      [ 81%]
 tests/unit/test_profile_service.py ..........                            [ 82%]
@@ -1177,7 +1186,8 @@ tests/unit/test_redis_client.py ..................                       [ 85%]
 tests/unit/test_schemas.py ......................                        [ 88%]
 tests/unit/test_social_auth_service.py ..............                    [ 89%]
 tests/unit/test_soft_deletion.py ..............................          [ 93%]
-tests/unit/test_verification_service.py .................................[ 98%]
+tests/unit/test_verification_service.py ................................ [ 98%]
+..............                                                           [100%]
 
 ---------- coverage: platform linux, python 3.12.12-final-0 ----------
 Name                                          Stmts   Miss  Cover  Missing
@@ -1190,7 +1200,7 @@ src/api/v1/endpoints/audit.py                    20      0   100%
 src/api/v1/endpoints/auth.py                    153     37    76%  126-142,148-150
 src/api/v1/endpoints/avatars.py                  55      3    95%  73-75
 src/api/v1/endpoints/contexts.py                101     12    88%  60,93,175-179
-src/api/v1/endpoints/oauth.py                   233     70    70%  164,206-207,250
+src/api/v1/endpoints/oauth.py                   233     65    72%  164,206-207,250
 src/api/v1/endpoints/privacy.py                  42      6    86%  77-78,110-116
 src/api/v1/endpoints/profiles.py                 86     37    57%  49-52,61-62,77
 src/api/v1/endpoints/social_auth.py              60      6    90%  74-75,166,171
@@ -1203,6 +1213,7 @@ src/core/encryption.py                           33      7    79%  38-39,47-48
 src/core/image.py                                54      0   100%
 src/core/redis_client.py                         89      6    93%  50,64,89,103
 src/core/security.py                             61      6    90%  137-138,146-149
+src/core/storage.py                             138     64    54%  61-70,78-87
 src/models/audit.py                              75      1    99%  122
 src/models/auth.py                               71      8    89%  78,92,94,103
 src/models/context.py                            62     15    76%  76,98,110-124
@@ -1213,7 +1224,7 @@ src/repositories/audit_repository.py             55      5    91%  148,150,158
 src/repositories/auth_repository.py             176     18    90%  31-33,128-138
 src/repositories/avatar_repository.py            34      2    94%  51,92
 src/repositories/context_repository.py           72      8    89%  101,119,129-136
-src/repositories/oauth_repository.py            236     27    89%  104,114,118-124
+src/repositories/oauth_repository.py            239     27    89%  104,114,118-124
 src/repositories/profile_repository.py           96      5    95%  58,166,184
 src/repositories/verification_repository.py      80     28    65%  111-112,130-138
 src/schemas/auth.py                             126      6    95%  41,49,104,192
@@ -1234,12 +1245,116 @@ src/services/verification_service.py            267     52    81%  85-87,93-95,1
 src/tasks/email_tasks.py                        123    103    16%  18-26,32-120
 src/tasks/expiry_tasks.py                        22     22     0%  7-45
 --------------------------------------------------------------------------
-TOTAL                                          5455    812    85%
+TOTAL                                          5458    807    85%
 
-======================= 751 passed, 1 warning in 13.54s ========================
+======================= 755 passed, 1 warning in 14.21s ========================
 \end{verbatim}
 \end{footnotesize}
 ```
+
+\newpage
+
+# Appendix D: Performance Benchmark Output {- #sec-appendix-benchmarks}
+
+The following output captures the complete `hey` benchmark runs against both local and production environments. Each run sends 200 requests at 10 concurrent connections with authenticated endpoints enabled (`--auth` flag). The benchmark script is available at `backend/scripts/benchmark.sh`.
+
+## Local Environment (Docker Compose + Supabase)
+
+Base URL: `http://localhost:8000`. Hardware: Apple Silicon, 16 GB+ RAM, local PostgreSQL via Supabase CLI.
+
+```{=latex}
+\begin{footnotesize}
+\begin{verbatim}
+>>> GET /health (baseline, no DB query)
+Summary:
+  Total:        0.0580 secs
+  Requests/sec: 3446.8100
+Latency distribution:
+  50% in 0.0014 secs    75% in 0.0017 secs
+  90% in 0.0022 secs    95% in 0.0222 secs    99% in 0.0326 secs
+Status code distribution:  [200] 200 responses
+
+>>> POST /api/v1/auth/login (Argon2id hashing)
+Summary:
+  Total:        8.2570 secs
+  Requests/sec: 24.2218
+Latency distribution:
+  50% in 0.3647 secs    75% in 0.3978 secs
+  90% in 0.4545 secs    95% in 1.2172 secs    99% in 1.2590 secs
+Status code distribution:  [200] 200 responses
+
+>>> GET /contexts/{id}/resolved (inheritance engine)
+Summary:
+  Total:        0.5671 secs
+  Requests/sec: 352.6681
+Latency distribution:
+  50% in 0.0274 secs    75% in 0.0316 secs
+  90% in 0.0354 secs    95% in 0.0384 secs    99% in 0.0453 secs
+Status code distribution:  [200] 200 responses
+
+>>> GET /contexts (list contexts)
+Summary:
+  Total:        0.3339 secs
+  Requests/sec: 598.9764
+Latency distribution:
+  50% in 0.0160 secs    75% in 0.0188 secs
+  90% in 0.0221 secs    95% in 0.0245 secs    99% in 0.0276 secs
+Status code distribution:  [200] 200 responses
+\end{verbatim}
+\end{footnotesize}
+```
+
+## Production Environment (Render Standard + Supabase Micro)
+
+Base URL: `https://identity-api-9hpf.onrender.com`. Infrastructure: Render standard plan (1 vCPU, 2 GB RAM, Frankfurt), Supabase Micro (2-core shared, 1 GB RAM, Frankfurt).
+
+```{=latex}
+\begin{footnotesize}
+\begin{verbatim}
+>>> GET /health (baseline, no DB query)
+Summary:
+  Total:        1.9968 secs
+  Requests/sec: 100.1608
+Latency distribution:
+  50% in 0.0710 secs    75% in 0.0843 secs
+  90% in 0.1056 secs    95% in 0.3196 secs    99% in 0.4102 secs
+Status code distribution:  [200] 200 responses
+
+>>> POST /api/v1/auth/login (Argon2id hashing)
+Summary:
+  Total:        47.4151 secs
+  Requests/sec: 4.2181
+Latency distribution:
+  50% in 2.4618 secs    75% in 2.6273 secs
+  90% in 2.8362 secs    95% in 2.9462 secs    99% in 3.1963 secs
+Status code distribution:  [200] 200 responses
+
+>>> GET /contexts/{id}/resolved (inheritance engine)
+Summary:
+  Total:        5.8644 secs
+  Requests/sec: 34.1042
+Latency distribution:
+  50% in 0.2527 secs    75% in 0.2727 secs
+  90% in 0.3718 secs    95% in 0.3870 secs    99% in 0.5528 secs
+Status code distribution:  [200] 200 responses
+
+>>> GET /contexts (list contexts)
+Summary:
+  Total:        4.5515 secs
+  Requests/sec: 43.9419
+Latency distribution:
+  50% in 0.1884 secs    75% in 0.2096 secs
+  90% in 0.2823 secs    95% in 0.3167 secs    99% in 0.4304 secs
+Status code distribution:  [200] 200 responses
+\end{verbatim}
+\end{footnotesize}
+```
+
+\newpage
+
+# Appendix E: Usability Testing Results {- #sec-appendix-usability}
+
+{{< include evaluation/participant-results-body.qmd >}}
 
 # References {-}
 

--- a/draft-report.qmd
+++ b/draft-report.qmd
@@ -679,7 +679,7 @@ A test suite of 755 automated tests spans unit and integration layers, achieving
 | Admin Operations | 18 | 85% | User management, purge, review |
 | Encryption | 9 | 79% | Fernet encryption, document security |
 
-Critical algorithms achieve near-complete coverage. The context service containing the inheritance engine has 93% coverage with tests validating full overrides, partial overrides with null inheritance, deprecated name filtering, temporal validity checking (HTTP 410 for expired contexts), and language fallback chains. The OAuth service has 96% coverage, with PKCE validation tested across valid verifiers, invalid verifiers, malformed challenges, and timing attack resistance. The privacy service achieves 99% coverage, validating data export formats and soft deletion with retention enforcement.
+Services implementing the system's core differentiators maintain coverage above 93%: privacy_service (99%), oauth_service (96%), and context_service (93%), covering GDPR-inspired data rights, PKCE-protected authorization, and inheritance resolution respectively.
 
 ## Functional Correctness Evaluation
 
@@ -787,8 +787,6 @@ Password hashing uses Argon2id with OWASP-recommended parameters (memory_cost=65
 
 Bandit, a static application security testing (SAST) tool for Python, runs in the CI pipeline at medium severity threshold against all source modules. The scanner detects common vulnerability patterns including hardcoded credentials, insecure use of cryptographic functions, SQL injection risks, and unsafe deserialization. Findings are triaged during development: true positives are fixed before merge, while false positives from test fixtures or intentional patterns receive inline suppression with documented justification. The medium severity threshold balances signal quality against noise, suppressing low-confidence informational findings that would otherwise generate false positives on standard library usage.
 
-The current security evaluation relies on bandit SAST scanning plus automated test coverage of known attack patterns rather than adversarial testing by external parties. This limitation reflects academic resource constraints rather than architectural deficiency; the security measures implemented follow industry best practices and would support professional penetration testing when resources permit.
-
 ## User Research and Validation
 
 Preliminary user research validates the project's core motivation through semi-structured interviews with individuals who experienced harm from inadequate context separation in existing identity systems. Four participants were recruited through online communities focused on digital privacy and identity protection. Each interview lasted approximately 25 minutes and explored their experiences with context collapse, coping strategies, and reactions to the proposed system design.
@@ -858,7 +856,7 @@ The evaluation identified several limitations requiring attention before final s
 
 Load testing with 10 concurrent connections characterizes baseline performance on the production infrastructure. Testing at higher concurrency levels (50-100+ simultaneous users) remains unvalidated and would require horizontal scaling or a higher-tier compute plan to produce meaningful results.
 
-System Usability Scale (SUS) testing was conducted with six participants spanning technical and non-technical backgrounds. The mean SUS score of 73.3 falls within the "acceptable" range, though high variance (SD = 22.2) indicates divergent user experiences. One participant (P5, non-technical background) scored 30, the only score below the acceptability threshold, suggesting that the OAuth consent flow and context management concepts require additional onboarding for users unfamiliar with identity management systems. Five improvement tasks were identified from participant feedback, of which three (dark mode contrast, Italian localization, and consent revocation discoverability) were resolved before submission. The remaining two, email verification visibility and OAuth scope terminology, require further iteration.
+The SUS evaluation detailed above yielded an "acceptable" mean score, but P5's outlier result (30.0) indicates that multi-context identity concepts require onboarding support for non-technical users. Two of the five identified improvement tasks (email verification visibility and OAuth scope terminology) remain open.
 
 Security testing is automated through the CI pipeline (bandit at medium severity, OWASP-aligned test suite) but does not include penetration testing by external parties. The academic context limits access to professional security auditors.
 

--- a/identity-management-background.bib
+++ b/identity-management-background.bib
@@ -552,6 +552,14 @@
   note = {Application logo generated using the Imagen 3 model via Google Gemini}
 }
 
+@misc{rakyll2024hey,
+  author = {Ismail, Jaana},
+  title = {hey: HTTP load generator, ApacheBench (ab) replacement},
+  year = {2024},
+  url = {https://github.com/rakyll/hey},
+  note = {Used for API performance benchmarking}
+}
+
 @misc{svgrepo2024keys,
   author = {{SVG Repo}},
   title = {Keys SVG Vector},

--- a/postman/BENCHMARKING.md
+++ b/postman/BENCHMARKING.md
@@ -1,0 +1,103 @@
+# Backend Performance Benchmarking
+
+Two complementary tools are available for measuring backend performance:
+`hey` for raw HTTP load testing and Newman iterations for functional regression timing.
+
+## Prerequisites
+
+```bash
+brew install hey           # HTTP load generator
+npm install -g newman      # Postman CLI runner
+```
+
+## hey - Endpoint Load Testing
+
+`hey` sends concurrent HTTP requests to a single endpoint and reports latency
+distributions (p50, p95, p99), throughput (requests/sec), and status code breakdowns.
+
+### Quick start
+
+```bash
+cd backend
+
+# Baseline: health endpoint, 200 requests, 10 concurrent
+./scripts/benchmark.sh
+
+# Higher concurrency
+./scripts/benchmark.sh -n 500 -c 20
+
+# Sustained load for 30 seconds
+./scripts/benchmark.sh -t 30s
+
+# Include authenticated endpoints (login, context resolution, context list)
+./scripts/benchmark.sh --auth
+
+# Custom base URL (e.g. staging)
+BASE_URL=https://identity-api-9hpf.onrender.com ./scripts/benchmark.sh
+```
+
+### Endpoints tested
+
+Without `--auth`:
+- `GET /health` - baseline with no database query
+- `GET /health/detailed` - includes database and Redis connectivity check
+
+With `--auth`:
+- `POST /api/v1/auth/login` - Argon2id password hashing under load
+- `GET /api/v1/profiles/{id}/contexts/{id}/resolved` - inheritance engine (O(n) resolution)
+- `GET /api/v1/profiles/{id}/contexts` - context listing with pagination
+
+### Interpreting results
+
+The thesis target is p95 response time under 200ms. In `hey` output, look for:
+
+```
+Latency distribution:
+  50% in X.XXXX secs
+  75% in X.XXXX secs
+  90% in X.XXXX secs
+  95% in X.XXXX secs    <-- this is the target metric
+  99% in X.XXXX secs
+```
+
+Status code distribution should show all 200s (or 401s for unauthenticated requests
+to protected endpoints). Any 5xx responses indicate server errors under load.
+
+## Newman - Functional Regression Timing
+
+Newman runs the full Postman collection repeatedly. This measures average response
+times across the entire API surface. Newman is single-threaded and sequential, so
+it does not test concurrency. It validates that functional correctness holds across
+repeated runs.
+
+### Quick start
+
+```bash
+cd backend
+
+# Full suite, 5 iterations
+./scripts/benchmark-newman.sh
+
+# More iterations for statistical significance
+./scripts/benchmark-newman.sh -n 20
+
+# Specific folder, 50 iterations
+./scripts/benchmark-newman.sh -f "01 - Health Checks" -n 50
+
+# Export JSON for programmatic analysis
+./scripts/benchmark-newman.sh -n 10 --json
+```
+
+### When to use which
+
+Use `hey` when:
+- Measuring raw throughput and latency under concurrent load
+- Testing a specific endpoint in isolation
+- Validating the p95 < 200ms target
+- Stress-testing Argon2id hashing or database connection pooling
+
+Use Newman iterations when:
+- Verifying no functional regressions across the full API
+- Measuring average response times across all endpoints
+- Generating JSON reports for automated analysis
+- Testing end-to-end flows (authentication, context creation, resolution)

--- a/postman/BENCHMARKING.md
+++ b/postman/BENCHMARKING.md
@@ -75,17 +75,6 @@ repeated runs.
 ```bash
 cd backend
 
-# Full suite, 5 iterations
-./scripts/benchmark-newman.sh
-
-# More iterations for statistical significance
-./scripts/benchmark-newman.sh -n 20
-
-# Specific folder, 50 iterations
-./scripts/benchmark-newman.sh -f "01 - Health Checks" -n 50
-
-# Export JSON for programmatic analysis
-./scripts/benchmark-newman.sh -n 10 --json
 ```
 
 ### When to use which
@@ -98,6 +87,5 @@ Use `hey` when:
 
 Use Newman iterations when:
 - Verifying no functional regressions across the full API
-- Measuring average response times across all endpoints
 - Generating JSON reports for automated analysis
 - Testing end-to-end flows (authentication, context creation, resolution)

--- a/render.yaml
+++ b/render.yaml
@@ -98,7 +98,7 @@ services:
   - type: web
     name: identity-api
     runtime: python
-    plan: starter
+    plan: standard
     region: frankfurt
     rootDir: backend
     buildCommand: pip install -r requirements.txt


### PR DESCRIPTION
## Summary
Add `benchmark.sh` wrapping `hey` for HTTP load testing (health, auth, context resolution endpoints)
Add `postman/BENCHMARKING.md` documenting both approaches and how to interpret results against the p95 < 200ms target

## Test plan
- [x] Install hey: `brew install hey`
- [x] Run `./scripts/benchmark.sh` 
- [x] Run `./scripts/benchmark.sh --auth` for authenticated endpoints