### PR TITLE
Add Indonesian language option to identity name UI

### DIFF
--- a/draft-report.qmd
+++ b/draft-report.qmd
@@ -928,9 +928,9 @@ The repository includes:
 
 ## Entity Relationship Diagram
 
-@fig-datamodel presents the domain model as an entity-relationship diagram showing the core aggregates and their relationships. BaseProfile serves as the root aggregate with a one-to-one relationship to AuthUsers for credentials and one-to-many relationships to IdentityNames, ContextProfiles, and VerificationDocuments. The OAuth 2.1 subsystem comprises OAuthScopes (reference data defining field-level access control), OAuthClients, OAuthConsents, and the token lifecycle tables (authorization codes, access tokens, refresh tokens). Refresh tokens form a self-referential rotation chain via `replaced_by_id` to support token rotation with replay detection. ContextProfiles optionally bind to OAuth tokens, consents, and verification documents, enabling context-aware third-party access with identity verification enforcement. AuditLog records form a hash-chained sequence linking each entry to its predecessor via `previous_hash`, providing tamper-evident accountability.
-
 ![Entity-relationship diagram showing domain model](images/erd-diagram.png){#fig-datamodel}
+
+@fig-datamodel presents the domain model as an entity-relationship diagram showing the core aggregates and their relationships. BaseProfile serves as the root aggregate with a one-to-one relationship to AuthUsers for credentials and one-to-many relationships to IdentityNames, ContextProfiles, and VerificationDocuments. The OAuth 2.1 subsystem comprises OAuthScopes (reference data defining field-level access control), OAuthClients, OAuthConsents, and the token lifecycle tables (authorization codes, access tokens, refresh tokens). Refresh tokens form a self-referential rotation chain via `replaced_by_id` to support token rotation with replay detection. ContextProfiles optionally bind to OAuth tokens, consents, and verification documents, enabling context-aware third-party access with identity verification enforcement. AuditLog records form a hash-chained sequence linking each entry to its predecessor via `previous_hash`, providing tamper-evident accountability.
 
 ## JSONB Data Examples
 

--- a/frontend/src/components/profile/IdentityNameManager.vue
+++ b/frontend/src/components/profile/IdentityNameManager.vue
@@ -35,6 +35,7 @@ const languageOptions = [
   { label: "Spanish (es)", value: "es" },
   { label: "Arabic (ar)", value: "ar" },
   { label: "Italian (it)", value: "it" },
+  { label: "Indonesian (id)", value: "id" },
 ];
 
 const form = ref({

--- a/frontend/src/views/ProfileEditView.vue
+++ b/frontend/src/views/ProfileEditView.vue
@@ -43,6 +43,7 @@ const languageOptions = [
   { label: "Spanish", value: "es" },
   { label: "Arabic", value: "ar" },
   { label: "Italian", value: "it" },
+  { label: "Indonesian", value: "id" },
 ];
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
Forgot Indonesian (id)  from the language dropdowns in IdentityNameManager and ProfileEditView
The seed data includes an Indonesian mononym profile (Sukarno) and the report references Indonesian mononyms

## Test plan
- [x] Verify Indonesian appears in the language dropdown when adding/editing an identity name
- [x] Verify Indonesian appears in the preferred language dropdown on profile edit
- [x] Confirm existing frontend tests still pass